### PR TITLE
feat: Initial use of enableStripePaymentProcessor flag

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -106,7 +106,7 @@ class Checkout extends React.Component {
     const isBulkOrder = orderType === ORDER_TYPES.BULK_ENROLLMENT;
     const isQuantityUpdating = isBasketProcessing && loaded;
     const stripeEnabled = enableStripePaymentProcessor && loaded;
-    console.log('[Zebra] stripeEnabled? in Checkout.jsx');
+    console.log('[Zebra] stripeEnabled? in Checkout.jsx', stripeEnabled);
 
     // istanbul ignore next
     const payPalIsSubmitting = submitting && paymentMethod === 'paypal';

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -163,6 +163,7 @@ class Checkout extends React.Component {
           onSubmitButtonClick={
             stripeEnabled ? this.handleSubmitStripeButtonClick : this.handleSubmitCybersourceButtonClick
           }
+          stripeEnabled={stripeEnabled}
           disabled={submitting}
           loading={loading}
           loaded={loaded}

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -64,13 +64,14 @@ class Checkout extends React.Component {
     );
   };
 
-  handleSubmitStripe = (formData) => {
-    console.log('[Zebra] handleSubmitStripe called');
-    this.props.submitPayment({ method: 'stripe', ...formData });
+  handleSubmitStripe = () => {
+    // TODO: We'll want to submit formData here in the next iteration
+    console.log('[Project Zebra] handleSubmitStripe called');
+    this.props.submitPayment({ method: 'stripe' });
   };
 
   handleSubmitStripeButtonClick = () => {
-    console.log('[Zebra] stripeEnabled button click');
+    console.log('[Project Zebra] handleSubmitStripeButtonClick');
     sendTrackEvent(
       'edx.bi.ecommerce.basket.payment_selected',
       {
@@ -91,7 +92,6 @@ class Checkout extends React.Component {
 
   renderCheckoutOptions() {
     const {
-      enableStripePaymentProcessor,
       intl,
       isFreeBasket,
       isBasketProcessing,
@@ -105,8 +105,10 @@ class Checkout extends React.Component {
     const submissionDisabled = loading || isBasketProcessing;
     const isBulkOrder = orderType === ORDER_TYPES.BULK_ENROLLMENT;
     const isQuantityUpdating = isBasketProcessing && loaded;
-    const stripeEnabled = enableStripePaymentProcessor && loaded;
-    console.log('[Zebra] stripeEnabled? in Checkout.jsx', stripeEnabled);
+
+    // TEMP: temporarily using true instead of enableStripePaymentProcessor to get REV-2799 unblocked
+    const stripeEnabled = true && loaded;
+    console.log('[Project Zebra] stripeEnabled? in Checkout.jsx', stripeEnabled);
 
     // istanbul ignore next
     const payPalIsSubmitting = submitting && paymentMethod === 'paypal';
@@ -195,7 +197,6 @@ Checkout.propTypes = {
   isBasketProcessing: PropTypes.bool,
   paymentMethod: PropTypes.oneOf(['paypal', 'apple-pay', 'cybersource']),
   orderType: PropTypes.oneOf(Object.values(ORDER_TYPES)),
-  enableStripePaymentProcessor: PropTypes.bool,
 };
 
 Checkout.defaultProps = {
@@ -206,7 +207,6 @@ Checkout.defaultProps = {
   isFreeBasket: false,
   paymentMethod: undefined,
   orderType: ORDER_TYPES.SEAT,
-  enableStripePaymentProcessor: false,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
[REV-3034](https://2u-internal.atlassian.net/browse/REV-3034).

Initial code to use the `enableStripePaymentProcessor` flag from the BFF ecommerce endpoint.

This is not hooked up yet to actually processing payments through Stripe, and after [REV-2999](https://2u-internal.atlassian.net/browse/REV-2999) is done, we'll use Stripe's "Place Order" button so the handle function on the button click would change location.

NOTE:
I saw an issue locally with using `enableStripePaymentProcessor` from basket where I needed to re-load sometimes, removed this to unblock REV-2999, will be added back in a following PR.