### PR TITLE
feat: Handle Stripe full form data on submit

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -30,4 +30,4 @@ APPLE_PAY_AUTHORIZE_URL='http://localhost:18130/payment/cybersource/apple-pay/au
 APPLE_PAY_SUPPORTED_NETWORKS='amex,discover,visa,masterCard',
 APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit',
 STRIPE_PUBLISHABLE_KEY=pk_test_51Li2KoIadiFyUl1xvRRiJohVzLNtnWUYNelHjMkzaf59Mq01ZMdsCGKzh9qyRwCIHBVEv0aQPkrvdH3OJ6F6WjSv00hdOx2EMb
-STRIPE_RESPONSE_URL='http://localhost:18130/payment/stripe/checkout',
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout,

--- a/.env.development-stage
+++ b/.env.development-stage
@@ -30,4 +30,4 @@ APPLE_PAY_AUTHORIZE_URL='/proxy/ecommerce/payment/cybersource/apple-pay/authoriz
 APPLE_PAY_SUPPORTED_NETWORKS='amex,discover,visa,masterCard'
 APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit'
 STRIPE_PUBLISHABLE_KEY=pk_test_51Li2KoIadiFyUl1xvRRiJohVzLNtnWUYNelHjMkzaf59Mq01ZMdsCGKzh9qyRwCIHBVEv0aQPkrvdH3OJ6F6WjSv00hdOx2EMb
-STRIPE_RESPONSE_URL='http://localhost:18130/payment/stripe/checkout'
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout

--- a/.env.test
+++ b/.env.test
@@ -30,4 +30,4 @@ APPLE_PAY_AUTHORIZE_URL='http://localhost:18130/payment/cybersource/apple-pay/au
 APPLE_PAY_SUPPORTED_NETWORKS='amex,discover,visa,masterCard',
 APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit',
 STRIPE_PUBLISHABLE_KEY=pk_test_51Li2KoIadiFyUl1xvRRiJohVzLNtnWUYNelHjMkzaf59Mq01ZMdsCGKzh9qyRwCIHBVEv0aQPkrvdH3OJ6F6WjSv00hdOx2EMb
-STRIPE_RESPONSE_URL='http://localhost:18130/payment/stripe/checkout',
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -140,6 +140,7 @@ class PaymentPage extends React.Component {
             'transaction-declined-message': (
               <TransactionDeclined />
             ),
+            /* TODO: should not render when using Stripe, likely need to refactor handleFetchCaptureKey */
             'capture-key-2mins-message': (
               <CaptureKeyTimeoutTwoMinutes />
             ),

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -222,7 +222,7 @@ export class PaymentFormComponent extends React.Component {
       <ErrorFocusContext.Provider value={this.state.firstErrorId}>
         {stripeEnabled && options.clientSecret && (
           <Elements options={options} stripe={stripePromise}>
-            <StripeCardPayment clientSecret={options.clientSecret} />
+            <StripeCardPayment clientSecret={options.clientSecret} disabled={disabled} isBulkOrder={isBulkOrder} />
             {/* onSubmitButtonClick={this.props.onSubmitButtonClick}
             onSubmitPayment={this.props.onSubmitPayment} */}
           </Elements>

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -218,6 +218,7 @@ export class PaymentFormComponent extends React.Component {
     if (disabled) { submitButtonState = 'disabled'; }
     // istanbul ignore if
     if (isProcessing) { submitButtonState = 'processing'; }
+
     return (
       <ErrorFocusContext.Provider value={this.state.firstErrorId}>
         {stripeEnabled && options.clientSecret && (

--- a/src/payment/checkout/payment-form/StripeCardPayment.jsx
+++ b/src/payment/checkout/payment-form/StripeCardPayment.jsx
@@ -1,15 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   PaymentElement,
   useStripe,
   useElements,
 } from '@stripe/react-stripe-js';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { AppContext } from '@edx/frontend-platform/react';
+
+import CardHolderInformation from './CardHolderInformation';
 // onSubmitPayment, onSubmitButtonClick
-export default function StripeCardPayment({ clientSecret }) {
+export default function StripeCardPayment({ clientSecret, disabled, isBulkOrder }) {
   const stripe = useStripe();
   const elements = useElements();
 
+  const context = useContext(AppContext);
   const [message, setMessage] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -55,6 +60,18 @@ export default function StripeCardPayment({ clientSecret }) {
       elements,
       confirmParams: {
         return_url: process.env.STRIPE_RESPONSE_URL,
+        billing_details: {
+          address: {
+            city: e.target[4].value,
+            country: e.target[5].value,
+            line1: e.target[2].value,
+            line2: e.target[3].value,
+            postal_code: e.target[7].value,
+            state: e.target[6].value,
+          },
+          email: context.authenticatedUser.email,
+          name: `${e.target[0].value} ${e.target[1].value}`,
+        },
       },
     });
 
@@ -74,6 +91,17 @@ export default function StripeCardPayment({ clientSecret }) {
 
   return (
     <form id="payment-form" onSubmit={handleSubmit}>
+      <CardHolderInformation
+        showBulkEnrollmentFields={isBulkOrder}
+        disabled={disabled}
+      />
+      <h5 aria-level="2">
+        <FormattedMessage
+          id="payment.card.details.billing.information.heading"
+          defaultMessage="Billing Information"
+          description="The heading for the credit card details billing information form"
+        />
+      </h5>
       <PaymentElement id="payment-element" />
       <button type="submit" disabled={isLoading || !stripe || !elements} id="submit">
         <span id="button-text">
@@ -88,10 +116,14 @@ export default function StripeCardPayment({ clientSecret }) {
 
 StripeCardPayment.propTypes = {
   clientSecret: PropTypes.string,
+  disabled: PropTypes.bool,
+  isBulkOrder: PropTypes.bool,
   // onSubmitPayment: PropTypes.func.isRequired,
   // onSubmitButtonClick: PropTypes.func.isRequired,
 };
 
 StripeCardPayment.defaultProps = {
   clientSecret: null,
+  disabled: false,
+  isBulkOrder: false,
 };

--- a/src/payment/checkout/payment-form/StripeCardPayment.jsx
+++ b/src/payment/checkout/payment-form/StripeCardPayment.jsx
@@ -5,7 +5,6 @@ import {
   useStripe,
   useElements,
 } from '@stripe/react-stripe-js';
-import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -60,7 +59,8 @@ export default function StripeCardPayment({ clientSecret, disabled, isBulkOrder 
     const { error } = await stripe.confirmPayment({
       elements,
       confirmParams: {
-        return_url: getConfig().STRIPE_RESPONSE_URL,
+        // TODO: add STRIPE_RESPONSE_URL to frontend-platform so we can use it with getConfig()
+        return_url: process.env.STRIPE_RESPONSE_URL,
         // TODO: refactor and use a checkout function (like checkoutWithToken)
         // to handle the formData in a non vanilla JS way
         payment_method_data: {

--- a/src/payment/checkout/payment-form/StripeCardPayment.jsx
+++ b/src/payment/checkout/payment-form/StripeCardPayment.jsx
@@ -5,6 +5,7 @@ import {
   useStripe,
   useElements,
 } from '@stripe/react-stripe-js';
+import { getConfig } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 
@@ -59,18 +60,22 @@ export default function StripeCardPayment({ clientSecret, disabled, isBulkOrder 
     const { error } = await stripe.confirmPayment({
       elements,
       confirmParams: {
-        return_url: process.env.STRIPE_RESPONSE_URL,
-        billing_details: {
-          address: {
-            city: e.target[4].value,
-            country: e.target[5].value,
-            line1: e.target[2].value,
-            line2: e.target[3].value,
-            postal_code: e.target[7].value,
-            state: e.target[6].value,
+        return_url: getConfig().STRIPE_RESPONSE_URL,
+        // TODO: refactor and use a checkout function (like checkoutWithToken)
+        // to handle the formData in a non vanilla JS way
+        payment_method_data: {
+          billing_details: {
+            address: {
+              city: e.target[4].value,
+              country: e.target[5].value,
+              line1: e.target[2].value,
+              line2: e.target[3].value,
+              postal_code: e.target[7].value,
+              state: e.target[6].value,
+            },
+            email: context.authenticatedUser.email,
+            name: `${e.target[0].value} ${e.target[1].value}`,
           },
-          email: context.authenticatedUser.email,
-          name: `${e.target[0].value} ${e.target[1].value}`,
         },
       },
     });

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -12,7 +12,7 @@ import {
   captureKeyDataReceived,
   captureKeyProcessing,
   CAPTURE_KEY_START_TIMEOUT,
-  captureKeyStartTimeout,
+  // captureKeyStartTimeout,
   microformStatus,
   fetchBasket,
   addCoupon,
@@ -154,7 +154,9 @@ export function* handleFetchCaptureKey() {
     yield put(microformStatus(STATUS_LOADING)); // we are refreshing the capture key
     const result = yield call(PaymentApiService.getCaptureKey);
     yield put(captureKeyDataReceived(result)); // update redux store with capture key data
-    yield put(captureKeyStartTimeout()); // only start the timer if we're using the capture key
+    // TODO: Not needed for Stripe, likely refactor to have Stripe's own hadleFetchCaptureKey
+    // yield put(captureKeyStartTimeout());
+    // only start the timer if we're using the capture key
   } catch (error) {
     yield call(handleErrors, error, true);
   } finally {


### PR DESCRIPTION
[REV-3001](https://2u-internal.atlassian.net/browse/REV-3001).

We're using the same form component that CyberSource uses (not specific to a payment provider), and for now we'll get the form data in a vanilla JS way.
