### PR TITLE
refactor: Payment form for Stripe and CyberSource

### DIFF
--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -331,6 +331,1707 @@ exports[`<PaymentPage /> Renders correctly in various states should render its d
             </button>
           </p>
         </div>
+        <form
+          noValidate={true}
+          onSubmit={[Function]}
+        >
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Card Holder Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="firstName"
+                >
+                  First Name (required)
+                </label>
+                <input
+                  autoComplete="given-name"
+                  className="form-control"
+                  disabled={false}
+                  id="firstName"
+                  name="firstName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="lastName"
+                >
+                  Last Name (required)
+                </label>
+                <input
+                  autoComplete="family-name"
+                  className="form-control"
+                  disabled={false}
+                  id="lastName"
+                  name="lastName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="address"
+                >
+                  Address (required)
+                </label>
+                <input
+                  autoComplete="street-address"
+                  className="form-control"
+                  disabled={false}
+                  id="address"
+                  maxLength="60"
+                  name="address"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="unit"
+                >
+                  Suite/Apartment Number
+                </label>
+                <input
+                  autoComplete="address-line2"
+                  className="form-control"
+                  disabled={false}
+                  id="unit"
+                  maxLength="29"
+                  name="unit"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="city"
+                >
+                  City (required)
+                </label>
+                <input
+                  autoComplete="address-level2"
+                  className="form-control"
+                  disabled={false}
+                  id="city"
+                  maxLength="32"
+                  name="city"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="country"
+                >
+                  Country (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <select
+                    autoComplete="country"
+                    className="form-control"
+                    disabled={false}
+                    id="country"
+                    name="country"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                        "WebkitAppearance": "none",
+                      }
+                    }
+                    value=""
+                  >
+                    <option
+                      value=""
+                    >
+                      Choose country
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                Array [
+                  <label
+                    htmlFor="state"
+                  >
+                    State/Province
+                  </label>,
+                  <input
+                    autoComplete="address-level1"
+                    className="form-control"
+                    disabled={false}
+                    id="state"
+                    maxLength="20"
+                    name="state"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    type="text"
+                    value=""
+                  />,
+                ]
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="postalCode"
+                >
+                  Zip/Postal Code
+                </label>
+                <input
+                  autoComplete="postal-code"
+                  className="form-control"
+                  disabled={false}
+                  id="postalCode"
+                  maxLength="9"
+                  name="postalCode"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Billing Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Card Number (required)
+                  </span>
+                  <div
+                    id="cardNumber"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Security Code (required)
+                  </span>
+                  <span
+                    className="ml-1"
+                    data-for="securityCodeHelp"
+                    data-tip={true}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-circle-question "
+                      data-icon="circle-question"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    className="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                    data-id="tooltip"
+                    id="securityCodeHelp"
+                  >
+                    <style
+                      aria-hidden="true"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  ",
+                        }
+                      }
+                    />
+                    The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                  </div>
+                  <div
+                    id="securityCode"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationMonth"
+                >
+                  Expiration Month (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationYear"
+                >
+                  Expiration Year (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-lg-6 form-group"
+          >
+            <div
+              className="row justify-content-end"
+            >
+              <div
+                className="skeleton btn btn-block btn-lg"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </form>
       </section>
     </div>
   </div>
@@ -501,6 +2202,1707 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
             </button>
           </p>
         </div>
+        <form
+          noValidate={true}
+          onSubmit={[Function]}
+        >
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Card Holder Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="firstName"
+                >
+                  First Name (required)
+                </label>
+                <input
+                  autoComplete="given-name"
+                  className="form-control"
+                  disabled={false}
+                  id="firstName"
+                  name="firstName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="lastName"
+                >
+                  Last Name (required)
+                </label>
+                <input
+                  autoComplete="family-name"
+                  className="form-control"
+                  disabled={false}
+                  id="lastName"
+                  name="lastName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="address"
+                >
+                  Address (required)
+                </label>
+                <input
+                  autoComplete="street-address"
+                  className="form-control"
+                  disabled={false}
+                  id="address"
+                  maxLength="60"
+                  name="address"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="unit"
+                >
+                  Suite/Apartment Number
+                </label>
+                <input
+                  autoComplete="address-line2"
+                  className="form-control"
+                  disabled={false}
+                  id="unit"
+                  maxLength="29"
+                  name="unit"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="city"
+                >
+                  City (required)
+                </label>
+                <input
+                  autoComplete="address-level2"
+                  className="form-control"
+                  disabled={false}
+                  id="city"
+                  maxLength="32"
+                  name="city"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="country"
+                >
+                  Country (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <select
+                    autoComplete="country"
+                    className="form-control"
+                    disabled={false}
+                    id="country"
+                    name="country"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                        "WebkitAppearance": "none",
+                      }
+                    }
+                    value=""
+                  >
+                    <option
+                      value=""
+                    >
+                      Choose country
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                Array [
+                  <label
+                    htmlFor="state"
+                  >
+                    State/Province
+                  </label>,
+                  <input
+                    autoComplete="address-level1"
+                    className="form-control"
+                    disabled={false}
+                    id="state"
+                    maxLength="20"
+                    name="state"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    type="text"
+                    value=""
+                  />,
+                ]
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="postalCode"
+                >
+                  Zip/Postal Code
+                </label>
+                <input
+                  autoComplete="postal-code"
+                  className="form-control"
+                  disabled={false}
+                  id="postalCode"
+                  maxLength="9"
+                  name="postalCode"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Billing Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Card Number (required)
+                  </span>
+                  <div
+                    id="cardNumber"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Security Code (required)
+                  </span>
+                  <span
+                    className="ml-1"
+                    data-for="securityCodeHelp"
+                    data-tip={true}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-circle-question "
+                      data-icon="circle-question"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    className="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                    data-id="tooltip"
+                    id="securityCodeHelp"
+                  >
+                    <style
+                      aria-hidden="true"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  ",
+                        }
+                      }
+                    />
+                    The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                  </div>
+                  <div
+                    id="securityCode"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationMonth"
+                >
+                  Expiration Month (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationYear"
+                >
+                  Expiration Year (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-lg-6 form-group"
+          >
+            <div
+              className="row justify-content-end"
+            >
+              <div
+                className="skeleton btn btn-block btn-lg"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </form>
       </section>
     </div>
   </div>
@@ -784,6 +4186,1767 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
             </button>
           </p>
         </div>
+        <form
+          noValidate={true}
+          onSubmit={[Function]}
+        >
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Card Holder Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="firstName"
+                >
+                  First Name (required)
+                </label>
+                <input
+                  autoComplete="given-name"
+                  className="form-control"
+                  disabled={false}
+                  id="firstName"
+                  name="firstName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="lastName"
+                >
+                  Last Name (required)
+                </label>
+                <input
+                  autoComplete="family-name"
+                  className="form-control"
+                  disabled={false}
+                  id="lastName"
+                  name="lastName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="organization"
+                >
+                  Organization (required)
+                </label>
+                <input
+                  autoComplete="organization"
+                  className="form-control"
+                  disabled={false}
+                  id="organization"
+                  name="organization"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="address"
+                >
+                  Address (required)
+                </label>
+                <input
+                  autoComplete="street-address"
+                  className="form-control"
+                  disabled={false}
+                  id="address"
+                  maxLength="60"
+                  name="address"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="unit"
+                >
+                  Suite/Apartment Number
+                </label>
+                <input
+                  autoComplete="address-line2"
+                  className="form-control"
+                  disabled={false}
+                  id="unit"
+                  maxLength="29"
+                  name="unit"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="city"
+                >
+                  City (required)
+                </label>
+                <input
+                  autoComplete="address-level2"
+                  className="form-control"
+                  disabled={false}
+                  id="city"
+                  maxLength="32"
+                  name="city"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="country"
+                >
+                  Country (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <select
+                    autoComplete="country"
+                    className="form-control"
+                    disabled={false}
+                    id="country"
+                    name="country"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                        "WebkitAppearance": "none",
+                      }
+                    }
+                    value=""
+                  >
+                    <option
+                      value=""
+                    >
+                      Choose country
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                Array [
+                  <label
+                    htmlFor="state"
+                  >
+                    State/Province
+                  </label>,
+                  <input
+                    autoComplete="address-level1"
+                    className="form-control"
+                    disabled={false}
+                    id="state"
+                    maxLength="20"
+                    name="state"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    type="text"
+                    value=""
+                  />,
+                ]
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="postalCode"
+                >
+                  Zip/Postal Code
+                </label>
+                <input
+                  autoComplete="postal-code"
+                  className="form-control"
+                  disabled={false}
+                  id="postalCode"
+                  maxLength="9"
+                  name="postalCode"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row form-group justify-content-start align-items-center"
+            >
+              <div
+                className="col-0 pr-0 pl-3"
+              >
+                <input
+                  checked={false}
+                  className="form-control"
+                  disabled={false}
+                  id="purchasedForOrganization"
+                  name="purchasedForOrganization"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="checkbox"
+                  value=""
+                />
+              </div>
+              <div
+                className="col"
+              >
+                <label
+                  className="mb-0"
+                  htmlFor="purchasedForOrganization"
+                >
+                  I am purchasing on behalf of my employer or other professional organization
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Billing Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Card Number (required)
+                  </span>
+                  <div
+                    id="cardNumber"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Security Code (required)
+                  </span>
+                  <span
+                    className="ml-1"
+                    data-for="securityCodeHelp"
+                    data-tip={true}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-circle-question "
+                      data-icon="circle-question"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    className="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                    data-id="tooltip"
+                    id="securityCodeHelp"
+                  >
+                    <style
+                      aria-hidden="true"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  ",
+                        }
+                      }
+                    />
+                    The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                  </div>
+                  <div
+                    id="securityCode"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationMonth"
+                >
+                  Expiration Month (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationYear"
+                >
+                  Expiration Year (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-lg-6 form-group"
+          >
+            <div
+              className="row justify-content-end"
+            >
+              <div
+                className="skeleton btn btn-block btn-lg"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </form>
       </section>
     </div>
   </div>
@@ -969,6 +6132,1707 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
             </button>
           </p>
         </div>
+        <form
+          noValidate={true}
+          onSubmit={[Function]}
+        >
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Card Holder Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="firstName"
+                >
+                  First Name (required)
+                </label>
+                <input
+                  autoComplete="given-name"
+                  className="form-control"
+                  disabled={false}
+                  id="firstName"
+                  name="firstName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="lastName"
+                >
+                  Last Name (required)
+                </label>
+                <input
+                  autoComplete="family-name"
+                  className="form-control"
+                  disabled={false}
+                  id="lastName"
+                  name="lastName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="address"
+                >
+                  Address (required)
+                </label>
+                <input
+                  autoComplete="street-address"
+                  className="form-control"
+                  disabled={false}
+                  id="address"
+                  maxLength="60"
+                  name="address"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="unit"
+                >
+                  Suite/Apartment Number
+                </label>
+                <input
+                  autoComplete="address-line2"
+                  className="form-control"
+                  disabled={false}
+                  id="unit"
+                  maxLength="29"
+                  name="unit"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="city"
+                >
+                  City (required)
+                </label>
+                <input
+                  autoComplete="address-level2"
+                  className="form-control"
+                  disabled={false}
+                  id="city"
+                  maxLength="32"
+                  name="city"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="country"
+                >
+                  Country (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <select
+                    autoComplete="country"
+                    className="form-control"
+                    disabled={false}
+                    id="country"
+                    name="country"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                        "WebkitAppearance": "none",
+                      }
+                    }
+                    value=""
+                  >
+                    <option
+                      value=""
+                    >
+                      Choose country
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                Array [
+                  <label
+                    htmlFor="state"
+                  >
+                    State/Province
+                  </label>,
+                  <input
+                    autoComplete="address-level1"
+                    className="form-control"
+                    disabled={false}
+                    id="state"
+                    maxLength="20"
+                    name="state"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    type="text"
+                    value=""
+                  />,
+                ]
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="postalCode"
+                >
+                  Zip/Postal Code
+                </label>
+                <input
+                  autoComplete="postal-code"
+                  className="form-control"
+                  disabled={false}
+                  id="postalCode"
+                  maxLength="9"
+                  name="postalCode"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Billing Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Card Number (required)
+                  </span>
+                  <div
+                    id="cardNumber"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Security Code (required)
+                  </span>
+                  <span
+                    className="ml-1"
+                    data-for="securityCodeHelp"
+                    data-tip={true}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-circle-question "
+                      data-icon="circle-question"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    className="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                    data-id="tooltip"
+                    id="securityCodeHelp"
+                  >
+                    <style
+                      aria-hidden="true"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  ",
+                        }
+                      }
+                    />
+                    The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                  </div>
+                  <div
+                    id="securityCode"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationMonth"
+                >
+                  Expiration Month (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationYear"
+                >
+                  Expiration Year (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-lg-6 form-group"
+          >
+            <div
+              className="row justify-content-end"
+            >
+              <div
+                className="skeleton btn btn-block btn-lg"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </form>
       </section>
     </div>
   </div>
@@ -1163,6 +8027,1707 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
             </button>
           </p>
         </div>
+        <form
+          noValidate={true}
+          onSubmit={[Function]}
+        >
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Card Holder Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="firstName"
+                >
+                  First Name (required)
+                </label>
+                <input
+                  autoComplete="given-name"
+                  className="form-control"
+                  disabled={false}
+                  id="firstName"
+                  name="firstName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="lastName"
+                >
+                  Last Name (required)
+                </label>
+                <input
+                  autoComplete="family-name"
+                  className="form-control"
+                  disabled={false}
+                  id="lastName"
+                  name="lastName"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="address"
+                >
+                  Address (required)
+                </label>
+                <input
+                  autoComplete="street-address"
+                  className="form-control"
+                  disabled={false}
+                  id="address"
+                  maxLength="60"
+                  name="address"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="unit"
+                >
+                  Suite/Apartment Number
+                </label>
+                <input
+                  autoComplete="address-line2"
+                  className="form-control"
+                  disabled={false}
+                  id="unit"
+                  maxLength="29"
+                  name="unit"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="city"
+                >
+                  City (required)
+                </label>
+                <input
+                  autoComplete="address-level2"
+                  className="form-control"
+                  disabled={false}
+                  id="city"
+                  maxLength="32"
+                  name="city"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  required={true}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="country"
+                >
+                  Country (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <select
+                    autoComplete="country"
+                    className="form-control"
+                    disabled={false}
+                    id="country"
+                    name="country"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    required={true}
+                    style={
+                      Object {
+                        "MozAppearance": "none",
+                        "WebkitAppearance": "none",
+                      }
+                    }
+                    value=""
+                  >
+                    <option
+                      value=""
+                    >
+                      Choose country
+                    </option>
+                    <option
+                      value="AF"
+                    >
+                      Afghanistan
+                    </option>
+                    <option
+                      value="AL"
+                    >
+                      Albania
+                    </option>
+                    <option
+                      value="DZ"
+                    >
+                      Algeria
+                    </option>
+                    <option
+                      value="AS"
+                    >
+                      American Samoa
+                    </option>
+                    <option
+                      value="AD"
+                    >
+                      Andorra
+                    </option>
+                    <option
+                      value="AO"
+                    >
+                      Angola
+                    </option>
+                    <option
+                      value="AI"
+                    >
+                      Anguilla
+                    </option>
+                    <option
+                      value="AQ"
+                    >
+                      Antarctica
+                    </option>
+                    <option
+                      value="AG"
+                    >
+                      Antigua and Barbuda
+                    </option>
+                    <option
+                      value="AR"
+                    >
+                      Argentina
+                    </option>
+                    <option
+                      value="AM"
+                    >
+                      Armenia
+                    </option>
+                    <option
+                      value="AW"
+                    >
+                      Aruba
+                    </option>
+                    <option
+                      value="AU"
+                    >
+                      Australia
+                    </option>
+                    <option
+                      value="AT"
+                    >
+                      Austria
+                    </option>
+                    <option
+                      value="AZ"
+                    >
+                      Azerbaijan
+                    </option>
+                    <option
+                      value="BS"
+                    >
+                      Bahamas
+                    </option>
+                    <option
+                      value="BH"
+                    >
+                      Bahrain
+                    </option>
+                    <option
+                      value="BD"
+                    >
+                      Bangladesh
+                    </option>
+                    <option
+                      value="BB"
+                    >
+                      Barbados
+                    </option>
+                    <option
+                      value="BY"
+                    >
+                      Belarus
+                    </option>
+                    <option
+                      value="BE"
+                    >
+                      Belgium
+                    </option>
+                    <option
+                      value="BZ"
+                    >
+                      Belize
+                    </option>
+                    <option
+                      value="BJ"
+                    >
+                      Benin
+                    </option>
+                    <option
+                      value="BM"
+                    >
+                      Bermuda
+                    </option>
+                    <option
+                      value="BT"
+                    >
+                      Bhutan
+                    </option>
+                    <option
+                      value="BO"
+                    >
+                      Bolivia
+                    </option>
+                    <option
+                      value="BA"
+                    >
+                      Bosnia and Herzegovina
+                    </option>
+                    <option
+                      value="BW"
+                    >
+                      Botswana
+                    </option>
+                    <option
+                      value="BV"
+                    >
+                      Bouvet Island
+                    </option>
+                    <option
+                      value="BR"
+                    >
+                      Brazil
+                    </option>
+                    <option
+                      value="IO"
+                    >
+                      British Indian Ocean Territory
+                    </option>
+                    <option
+                      value="BN"
+                    >
+                      Brunei Darussalam
+                    </option>
+                    <option
+                      value="BG"
+                    >
+                      Bulgaria
+                    </option>
+                    <option
+                      value="BF"
+                    >
+                      Burkina Faso
+                    </option>
+                    <option
+                      value="BI"
+                    >
+                      Burundi
+                    </option>
+                    <option
+                      value="KH"
+                    >
+                      Cambodia
+                    </option>
+                    <option
+                      value="CM"
+                    >
+                      Cameroon
+                    </option>
+                    <option
+                      value="CA"
+                    >
+                      Canada
+                    </option>
+                    <option
+                      value="CV"
+                    >
+                      Cape Verde
+                    </option>
+                    <option
+                      value="KY"
+                    >
+                      Cayman Islands
+                    </option>
+                    <option
+                      value="CF"
+                    >
+                      Central African Republic
+                    </option>
+                    <option
+                      value="TD"
+                    >
+                      Chad
+                    </option>
+                    <option
+                      value="CL"
+                    >
+                      Chile
+                    </option>
+                    <option
+                      value="CN"
+                    >
+                      China
+                    </option>
+                    <option
+                      value="CX"
+                    >
+                      Christmas Island
+                    </option>
+                    <option
+                      value="CC"
+                    >
+                      Cocos (Keeling) Islands
+                    </option>
+                    <option
+                      value="CO"
+                    >
+                      Colombia
+                    </option>
+                    <option
+                      value="KM"
+                    >
+                      Comoros
+                    </option>
+                    <option
+                      value="CG"
+                    >
+                      Congo
+                    </option>
+                    <option
+                      value="CD"
+                    >
+                      Congo, the Democratic Republic of the
+                    </option>
+                    <option
+                      value="CK"
+                    >
+                      Cook Islands
+                    </option>
+                    <option
+                      value="CR"
+                    >
+                      Costa Rica
+                    </option>
+                    <option
+                      value="CI"
+                    >
+                      Cote D'Ivoire
+                    </option>
+                    <option
+                      value="HR"
+                    >
+                      Croatia
+                    </option>
+                    <option
+                      value="CU"
+                    >
+                      Cuba
+                    </option>
+                    <option
+                      value="CY"
+                    >
+                      Cyprus
+                    </option>
+                    <option
+                      value="CZ"
+                    >
+                      Czech Republic
+                    </option>
+                    <option
+                      value="DK"
+                    >
+                      Denmark
+                    </option>
+                    <option
+                      value="DJ"
+                    >
+                      Djibouti
+                    </option>
+                    <option
+                      value="DM"
+                    >
+                      Dominica
+                    </option>
+                    <option
+                      value="DO"
+                    >
+                      Dominican Republic
+                    </option>
+                    <option
+                      value="EC"
+                    >
+                      Ecuador
+                    </option>
+                    <option
+                      value="EG"
+                    >
+                      Egypt
+                    </option>
+                    <option
+                      value="SV"
+                    >
+                      El Salvador
+                    </option>
+                    <option
+                      value="GQ"
+                    >
+                      Equatorial Guinea
+                    </option>
+                    <option
+                      value="ER"
+                    >
+                      Eritrea
+                    </option>
+                    <option
+                      value="EE"
+                    >
+                      Estonia
+                    </option>
+                    <option
+                      value="ET"
+                    >
+                      Ethiopia
+                    </option>
+                    <option
+                      value="FK"
+                    >
+                      Falkland Islands (Malvinas)
+                    </option>
+                    <option
+                      value="FO"
+                    >
+                      Faroe Islands
+                    </option>
+                    <option
+                      value="FJ"
+                    >
+                      Fiji
+                    </option>
+                    <option
+                      value="FI"
+                    >
+                      Finland
+                    </option>
+                    <option
+                      value="FR"
+                    >
+                      France
+                    </option>
+                    <option
+                      value="GF"
+                    >
+                      French Guiana
+                    </option>
+                    <option
+                      value="PF"
+                    >
+                      French Polynesia
+                    </option>
+                    <option
+                      value="TF"
+                    >
+                      French Southern Territories
+                    </option>
+                    <option
+                      value="GA"
+                    >
+                      Gabon
+                    </option>
+                    <option
+                      value="GM"
+                    >
+                      Gambia
+                    </option>
+                    <option
+                      value="GE"
+                    >
+                      Georgia
+                    </option>
+                    <option
+                      value="DE"
+                    >
+                      Germany
+                    </option>
+                    <option
+                      value="GH"
+                    >
+                      Ghana
+                    </option>
+                    <option
+                      value="GI"
+                    >
+                      Gibraltar
+                    </option>
+                    <option
+                      value="GR"
+                    >
+                      Greece
+                    </option>
+                    <option
+                      value="GL"
+                    >
+                      Greenland
+                    </option>
+                    <option
+                      value="GD"
+                    >
+                      Grenada
+                    </option>
+                    <option
+                      value="GP"
+                    >
+                      Guadeloupe
+                    </option>
+                    <option
+                      value="GU"
+                    >
+                      Guam
+                    </option>
+                    <option
+                      value="GT"
+                    >
+                      Guatemala
+                    </option>
+                    <option
+                      value="GN"
+                    >
+                      Guinea
+                    </option>
+                    <option
+                      value="GW"
+                    >
+                      Guinea-Bissau
+                    </option>
+                    <option
+                      value="GY"
+                    >
+                      Guyana
+                    </option>
+                    <option
+                      value="HT"
+                    >
+                      Haiti
+                    </option>
+                    <option
+                      value="HM"
+                    >
+                      Heard Island and Mcdonald Islands
+                    </option>
+                    <option
+                      value="VA"
+                    >
+                      Holy See (Vatican City State)
+                    </option>
+                    <option
+                      value="HN"
+                    >
+                      Honduras
+                    </option>
+                    <option
+                      value="HK"
+                    >
+                      Hong Kong
+                    </option>
+                    <option
+                      value="HU"
+                    >
+                      Hungary
+                    </option>
+                    <option
+                      value="IS"
+                    >
+                      Iceland
+                    </option>
+                    <option
+                      value="IN"
+                    >
+                      India
+                    </option>
+                    <option
+                      value="ID"
+                    >
+                      Indonesia
+                    </option>
+                    <option
+                      value="IR"
+                    >
+                      Iran, Islamic Republic of
+                    </option>
+                    <option
+                      value="IQ"
+                    >
+                      Iraq
+                    </option>
+                    <option
+                      value="IE"
+                    >
+                      Ireland
+                    </option>
+                    <option
+                      value="IL"
+                    >
+                      Israel
+                    </option>
+                    <option
+                      value="IT"
+                    >
+                      Italy
+                    </option>
+                    <option
+                      value="JM"
+                    >
+                      Jamaica
+                    </option>
+                    <option
+                      value="JP"
+                    >
+                      Japan
+                    </option>
+                    <option
+                      value="JO"
+                    >
+                      Jordan
+                    </option>
+                    <option
+                      value="KZ"
+                    >
+                      Kazakhstan
+                    </option>
+                    <option
+                      value="KE"
+                    >
+                      Kenya
+                    </option>
+                    <option
+                      value="KI"
+                    >
+                      Kiribati
+                    </option>
+                    <option
+                      value="KP"
+                    >
+                      North Korea
+                    </option>
+                    <option
+                      value="KR"
+                    >
+                      South Korea
+                    </option>
+                    <option
+                      value="KW"
+                    >
+                      Kuwait
+                    </option>
+                    <option
+                      value="KG"
+                    >
+                      Kyrgyzstan
+                    </option>
+                    <option
+                      value="LA"
+                    >
+                      Lao People's Democratic Republic
+                    </option>
+                    <option
+                      value="LV"
+                    >
+                      Latvia
+                    </option>
+                    <option
+                      value="LB"
+                    >
+                      Lebanon
+                    </option>
+                    <option
+                      value="LS"
+                    >
+                      Lesotho
+                    </option>
+                    <option
+                      value="LR"
+                    >
+                      Liberia
+                    </option>
+                    <option
+                      value="LY"
+                    >
+                      Libya
+                    </option>
+                    <option
+                      value="LI"
+                    >
+                      Liechtenstein
+                    </option>
+                    <option
+                      value="LT"
+                    >
+                      Lithuania
+                    </option>
+                    <option
+                      value="LU"
+                    >
+                      Luxembourg
+                    </option>
+                    <option
+                      value="MO"
+                    >
+                      Macao
+                    </option>
+                    <option
+                      value="MG"
+                    >
+                      Madagascar
+                    </option>
+                    <option
+                      value="MW"
+                    >
+                      Malawi
+                    </option>
+                    <option
+                      value="MY"
+                    >
+                      Malaysia
+                    </option>
+                    <option
+                      value="MV"
+                    >
+                      Maldives
+                    </option>
+                    <option
+                      value="ML"
+                    >
+                      Mali
+                    </option>
+                    <option
+                      value="MT"
+                    >
+                      Malta
+                    </option>
+                    <option
+                      value="MH"
+                    >
+                      Marshall Islands
+                    </option>
+                    <option
+                      value="MQ"
+                    >
+                      Martinique
+                    </option>
+                    <option
+                      value="MR"
+                    >
+                      Mauritania
+                    </option>
+                    <option
+                      value="MU"
+                    >
+                      Mauritius
+                    </option>
+                    <option
+                      value="YT"
+                    >
+                      Mayotte
+                    </option>
+                    <option
+                      value="MX"
+                    >
+                      Mexico
+                    </option>
+                    <option
+                      value="FM"
+                    >
+                      Micronesia, Federated States of
+                    </option>
+                    <option
+                      value="MD"
+                    >
+                      Moldova, Republic of
+                    </option>
+                    <option
+                      value="MC"
+                    >
+                      Monaco
+                    </option>
+                    <option
+                      value="MN"
+                    >
+                      Mongolia
+                    </option>
+                    <option
+                      value="MS"
+                    >
+                      Montserrat
+                    </option>
+                    <option
+                      value="MA"
+                    >
+                      Morocco
+                    </option>
+                    <option
+                      value="MZ"
+                    >
+                      Mozambique
+                    </option>
+                    <option
+                      value="MM"
+                    >
+                      Myanmar
+                    </option>
+                    <option
+                      value="NA"
+                    >
+                      Namibia
+                    </option>
+                    <option
+                      value="NR"
+                    >
+                      Nauru
+                    </option>
+                    <option
+                      value="NP"
+                    >
+                      Nepal
+                    </option>
+                    <option
+                      value="NL"
+                    >
+                      Netherlands
+                    </option>
+                    <option
+                      value="NC"
+                    >
+                      New Caledonia
+                    </option>
+                    <option
+                      value="NZ"
+                    >
+                      New Zealand
+                    </option>
+                    <option
+                      value="NI"
+                    >
+                      Nicaragua
+                    </option>
+                    <option
+                      value="NE"
+                    >
+                      Niger
+                    </option>
+                    <option
+                      value="NG"
+                    >
+                      Nigeria
+                    </option>
+                    <option
+                      value="NU"
+                    >
+                      Niue
+                    </option>
+                    <option
+                      value="NF"
+                    >
+                      Norfolk Island
+                    </option>
+                    <option
+                      value="MK"
+                    >
+                      North Macedonia, Republic of
+                    </option>
+                    <option
+                      value="MP"
+                    >
+                      Northern Mariana Islands
+                    </option>
+                    <option
+                      value="NO"
+                    >
+                      Norway
+                    </option>
+                    <option
+                      value="OM"
+                    >
+                      Oman
+                    </option>
+                    <option
+                      value="PK"
+                    >
+                      Pakistan
+                    </option>
+                    <option
+                      value="PW"
+                    >
+                      Palau
+                    </option>
+                    <option
+                      value="PS"
+                    >
+                      Palestinian Territory, Occupied
+                    </option>
+                    <option
+                      value="PA"
+                    >
+                      Panama
+                    </option>
+                    <option
+                      value="PG"
+                    >
+                      Papua New Guinea
+                    </option>
+                    <option
+                      value="PY"
+                    >
+                      Paraguay
+                    </option>
+                    <option
+                      value="PE"
+                    >
+                      Peru
+                    </option>
+                    <option
+                      value="PH"
+                    >
+                      Philippines
+                    </option>
+                    <option
+                      value="PN"
+                    >
+                      Pitcairn
+                    </option>
+                    <option
+                      value="PL"
+                    >
+                      Poland
+                    </option>
+                    <option
+                      value="PT"
+                    >
+                      Portugal
+                    </option>
+                    <option
+                      value="PR"
+                    >
+                      Puerto Rico
+                    </option>
+                    <option
+                      value="QA"
+                    >
+                      Qatar
+                    </option>
+                    <option
+                      value="RE"
+                    >
+                      Reunion
+                    </option>
+                    <option
+                      value="RO"
+                    >
+                      Romania
+                    </option>
+                    <option
+                      value="RU"
+                    >
+                      Russian Federation
+                    </option>
+                    <option
+                      value="RW"
+                    >
+                      Rwanda
+                    </option>
+                    <option
+                      value="SH"
+                    >
+                      Saint Helena
+                    </option>
+                    <option
+                      value="KN"
+                    >
+                      Saint Kitts and Nevis
+                    </option>
+                    <option
+                      value="LC"
+                    >
+                      Saint Lucia
+                    </option>
+                    <option
+                      value="PM"
+                    >
+                      Saint Pierre and Miquelon
+                    </option>
+                    <option
+                      value="VC"
+                    >
+                      Saint Vincent and the Grenadines
+                    </option>
+                    <option
+                      value="WS"
+                    >
+                      Samoa
+                    </option>
+                    <option
+                      value="SM"
+                    >
+                      San Marino
+                    </option>
+                    <option
+                      value="ST"
+                    >
+                      Sao Tome and Principe
+                    </option>
+                    <option
+                      value="SA"
+                    >
+                      Saudi Arabia
+                    </option>
+                    <option
+                      value="SN"
+                    >
+                      Senegal
+                    </option>
+                    <option
+                      value="SC"
+                    >
+                      Seychelles
+                    </option>
+                    <option
+                      value="SL"
+                    >
+                      Sierra Leone
+                    </option>
+                    <option
+                      value="SG"
+                    >
+                      Singapore
+                    </option>
+                    <option
+                      value="SK"
+                    >
+                      Slovakia
+                    </option>
+                    <option
+                      value="SI"
+                    >
+                      Slovenia
+                    </option>
+                    <option
+                      value="SB"
+                    >
+                      Solomon Islands
+                    </option>
+                    <option
+                      value="SO"
+                    >
+                      Somalia
+                    </option>
+                    <option
+                      value="ZA"
+                    >
+                      South Africa
+                    </option>
+                    <option
+                      value="GS"
+                    >
+                      South Georgia and the South Sandwich Islands
+                    </option>
+                    <option
+                      value="ES"
+                    >
+                      Spain
+                    </option>
+                    <option
+                      value="LK"
+                    >
+                      Sri Lanka
+                    </option>
+                    <option
+                      value="SD"
+                    >
+                      Sudan
+                    </option>
+                    <option
+                      value="SR"
+                    >
+                      Suriname
+                    </option>
+                    <option
+                      value="SJ"
+                    >
+                      Svalbard and Jan Mayen
+                    </option>
+                    <option
+                      value="SZ"
+                    >
+                      Swaziland
+                    </option>
+                    <option
+                      value="SE"
+                    >
+                      Sweden
+                    </option>
+                    <option
+                      value="CH"
+                    >
+                      Switzerland
+                    </option>
+                    <option
+                      value="SY"
+                    >
+                      Syrian Arab Republic
+                    </option>
+                    <option
+                      value="TW"
+                    >
+                      Taiwan
+                    </option>
+                    <option
+                      value="TJ"
+                    >
+                      Tajikistan
+                    </option>
+                    <option
+                      value="TZ"
+                    >
+                      Tanzania, United Republic of
+                    </option>
+                    <option
+                      value="TH"
+                    >
+                      Thailand
+                    </option>
+                    <option
+                      value="TL"
+                    >
+                      Timor-Leste
+                    </option>
+                    <option
+                      value="TG"
+                    >
+                      Togo
+                    </option>
+                    <option
+                      value="TK"
+                    >
+                      Tokelau
+                    </option>
+                    <option
+                      value="TO"
+                    >
+                      Tonga
+                    </option>
+                    <option
+                      value="TT"
+                    >
+                      Trinidad and Tobago
+                    </option>
+                    <option
+                      value="TN"
+                    >
+                      Tunisia
+                    </option>
+                    <option
+                      value="TR"
+                    >
+                      Turkey
+                    </option>
+                    <option
+                      value="TM"
+                    >
+                      Turkmenistan
+                    </option>
+                    <option
+                      value="TC"
+                    >
+                      Turks and Caicos Islands
+                    </option>
+                    <option
+                      value="TV"
+                    >
+                      Tuvalu
+                    </option>
+                    <option
+                      value="UG"
+                    >
+                      Uganda
+                    </option>
+                    <option
+                      value="UA"
+                    >
+                      Ukraine
+                    </option>
+                    <option
+                      value="AE"
+                    >
+                      United Arab Emirates
+                    </option>
+                    <option
+                      value="GB"
+                    >
+                      United Kingdom
+                    </option>
+                    <option
+                      value="US"
+                    >
+                      United States of America
+                    </option>
+                    <option
+                      value="UM"
+                    >
+                      United States Minor Outlying Islands
+                    </option>
+                    <option
+                      value="UY"
+                    >
+                      Uruguay
+                    </option>
+                    <option
+                      value="UZ"
+                    >
+                      Uzbekistan
+                    </option>
+                    <option
+                      value="VU"
+                    >
+                      Vanuatu
+                    </option>
+                    <option
+                      value="VE"
+                    >
+                      Venezuela
+                    </option>
+                    <option
+                      value="VN"
+                    >
+                      Viet Nam
+                    </option>
+                    <option
+                      value="VG"
+                    >
+                      Virgin Islands, British
+                    </option>
+                    <option
+                      value="VI"
+                    >
+                      Virgin Islands, U.S.
+                    </option>
+                    <option
+                      value="WF"
+                    >
+                      Wallis and Futuna
+                    </option>
+                    <option
+                      value="EH"
+                    >
+                      Western Sahara
+                    </option>
+                    <option
+                      value="YE"
+                    >
+                      Yemen
+                    </option>
+                    <option
+                      value="ZM"
+                    >
+                      Zambia
+                    </option>
+                    <option
+                      value="ZW"
+                    >
+                      Zimbabwe
+                    </option>
+                    <option
+                      value="AX"
+                    >
+                      Åland Islands
+                    </option>
+                    <option
+                      value="BQ"
+                    >
+                      Bonaire, Sint Eustatius and Saba
+                    </option>
+                    <option
+                      value="CW"
+                    >
+                      Curaçao
+                    </option>
+                    <option
+                      value="GG"
+                    >
+                      Guernsey
+                    </option>
+                    <option
+                      value="IM"
+                    >
+                      Isle of Man
+                    </option>
+                    <option
+                      value="JE"
+                    >
+                      Jersey
+                    </option>
+                    <option
+                      value="ME"
+                    >
+                      Montenegro
+                    </option>
+                    <option
+                      value="BL"
+                    >
+                      Saint Barthélemy
+                    </option>
+                    <option
+                      value="MF"
+                    >
+                      Saint Martin (French part)
+                    </option>
+                    <option
+                      value="RS"
+                    >
+                      Serbia
+                    </option>
+                    <option
+                      value="SX"
+                    >
+                      Sint Maarten (Dutch part)
+                    </option>
+                    <option
+                      value="SS"
+                    >
+                      South Sudan
+                    </option>
+                    <option
+                      value="XK"
+                    >
+                      Kosovo
+                    </option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                Array [
+                  <label
+                    htmlFor="state"
+                  >
+                    State/Province
+                  </label>,
+                  <input
+                    autoComplete="address-level1"
+                    className="form-control"
+                    disabled={false}
+                    id="state"
+                    maxLength="20"
+                    name="state"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onDragStart={[Function]}
+                    onDrop={[Function]}
+                    onFocus={[Function]}
+                    type="text"
+                    value=""
+                  />,
+                ]
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="postalCode"
+                >
+                  Zip/Postal Code
+                </label>
+                <input
+                  autoComplete="postal-code"
+                  className="form-control"
+                  disabled={false}
+                  id="postalCode"
+                  maxLength="9"
+                  name="postalCode"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onDragStart={[Function]}
+                  onDrop={[Function]}
+                  onFocus={[Function]}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            className="basket-section"
+          >
+            <h5
+              aria-level="2"
+            >
+              Billing Information
+            </h5>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Card Number (required)
+                  </span>
+                  <div
+                    id="cardNumber"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <span>
+                  <span
+                    aria-hidden={true}
+                    className="microform-label"
+                  >
+                    Security Code (required)
+                  </span>
+                  <span
+                    className="ml-1"
+                    data-for="securityCodeHelp"
+                    data-tip={true}
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="svg-inline--fa fa-circle-question "
+                      data-icon="circle-question"
+                      data-prefix="fas"
+                      focusable="false"
+                      role="img"
+                      style={Object {}}
+                      viewBox="0 0 512 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M256 512c141.4 0 256-114.6 256-256S397.4 0 256 0S0 114.6 0 256S114.6 512 256 512zM169.8 165.3c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM288 352c0 17.7-14.3 32-32 32s-32-14.3-32-32s14.3-32 32-32s32 14.3 32 32z"
+                        fill="currentColor"
+                        style={Object {}}
+                      />
+                    </svg>
+                  </span>
+                  <div
+                    className="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                    data-id="tooltip"
+                    id="securityCodeHelp"
+                  >
+                    <style
+                      aria-hidden="true"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  ",
+                        }
+                      }
+                    />
+                    The three last digits in the signature area on the back of your card. For American Express, it is the four digits on the front of the card.
+                  </div>
+                  <div
+                    id="securityCode"
+                  />
+                  <div
+                    className="skeleton py-3"
+                  />
+                </span>
+              </div>
+            </div>
+            <div
+              className="row"
+            >
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationMonth"
+                >
+                  Expiration Month (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+              <div
+                className="col-lg-6 form-group"
+              >
+                <label
+                  htmlFor="cardExpirationYear"
+                >
+                  Expiration Year (required)
+                </label>
+                <div
+                  data-hj-suppress={true}
+                >
+                  <div
+                    className="skeleton py-3"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="col-lg-6 form-group"
+          >
+            <div
+              className="row justify-content-end"
+            >
+              <div
+                className="skeleton btn btn-block btn-lg"
+              >
+                 
+              </div>
+            </div>
+          </div>
+        </form>
       </section>
     </div>
   </div>

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -13,7 +13,7 @@ import { submitPayment } from '../data/actions';
 import AcceptedCardLogos from './assets/accepted-card-logos.png';
 
 import PaymentForm from './payment-form/PaymentForm';
-import StripeCardPayment from './payment-form/StripeCardPayment';
+import StripePaymentForm from './payment-form/StripePaymentForm';
 import FreeCheckoutOrderButton from './FreeCheckoutOrderButton';
 import { PayPalButton } from '../payment-methods/paypal';
 import { ORDER_TYPES } from '../data/constants';
@@ -171,7 +171,7 @@ class Checkout extends React.Component {
         </div>
         {enableStripePaymentProcessor && options.clientSecret ? (
           <Elements options={options} stripe={stripePromise}>
-            <StripeCardPayment
+            <StripePaymentForm
               onSubmitPayment={this.handleSubmitStripe}
               onSubmitButtonClick={this.handleSubmitStripeButtonClick}
               clientSecret={options.clientSecret}

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -93,6 +93,7 @@ class Checkout extends React.Component {
   renderCheckoutOptions() {
     console.log('[Project Zebra] props in Checkout.jsx', this.props);
     const {
+      enableStripePaymentProcessor,
       intl,
       isFreeBasket,
       isBasketProcessing,
@@ -102,14 +103,11 @@ class Checkout extends React.Component {
       submitting,
       orderType,
     } = this.props;
-
     const submissionDisabled = loading || isBasketProcessing;
     const isBulkOrder = orderType === ORDER_TYPES.BULK_ENROLLMENT;
     const isQuantityUpdating = isBasketProcessing && loaded;
 
-    // TEMP: temporarily using true instead of enableStripePaymentProcessor to get REV-2799 unblocked
-    const stripeEnabled = true;// && loaded;
-    console.log('[Project Zebra] stripeEnabled? in Checkout.jsx', stripeEnabled);
+    console.log('[Project Zebra] enableStripePaymentProcessor? in Checkout.jsx', enableStripePaymentProcessor);
 
     // istanbul ignore next
     const payPalIsSubmitting = submitting && paymentMethod === 'paypal';
@@ -159,16 +157,16 @@ class Checkout extends React.Component {
 
         <PaymentForm
           onSubmitPayment={
-            stripeEnabled ? this.handleSubmitStripe : this.handleSubmitCybersource
+            enableStripePaymentProcessor ? this.handleSubmitStripe : this.handleSubmitCybersource
           }
           onSubmitButtonClick={
-            stripeEnabled ? this.handleSubmitStripeButtonClick : this.handleSubmitCybersourceButtonClick
+            enableStripePaymentProcessor ? this.handleSubmitStripeButtonClick : this.handleSubmitCybersourceButtonClick
           }
-          stripeEnabled={stripeEnabled}
+          enableStripePaymentProcessor={enableStripePaymentProcessor}
           disabled={submitting}
           loading={loading}
           loaded={loaded}
-          isProcessing={stripeEnabled ? stripeIsSubmitting : cybersourceIsSubmitting}
+          isProcessing={enableStripePaymentProcessor ? stripeIsSubmitting : cybersourceIsSubmitting}
           isBulkOrder={isBulkOrder}
           isQuantityUpdating={isQuantityUpdating}
         />
@@ -199,6 +197,7 @@ Checkout.propTypes = {
   isBasketProcessing: PropTypes.bool,
   paymentMethod: PropTypes.oneOf(['paypal', 'apple-pay', 'cybersource']),
   orderType: PropTypes.oneOf(Object.values(ORDER_TYPES)),
+  enableStripePaymentProcessor: PropTypes.bool,
 };
 
 Checkout.defaultProps = {
@@ -209,6 +208,7 @@ Checkout.defaultProps = {
   isFreeBasket: false,
   paymentMethod: undefined,
   orderType: ORDER_TYPES.SEAT,
+  enableStripePaymentProcessor: false,
 };
 
 const mapStateToProps = (state) => ({

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { reduxForm, SubmissionError } from 'redux-form';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import { StatefulButton } from '@edx/paragon';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
+import { injectIntl } from '@edx/frontend-platform/i18n';
 
 import CardDetails from './CardDetails';
 import CardHolderInformation from './CardHolderInformation';
+import PlaceOrderButton from './PlaceOrderButton';
 import StripeCardPayment from './StripeCardPayment';
 import getStates from './utils/countryStatesMap';
 import { updateCaptureKeySelector, updateSubmitErrorsSelector } from '../../data/selectors';
@@ -213,11 +213,8 @@ export class PaymentFormComponent extends React.Component {
       clientSecret: this.props.captureKeyId,
       appearance,
     };
-    let submitButtonState = 'default';
-    // istanbul ignore if
-    if (disabled) { submitButtonState = 'disabled'; }
-    // istanbul ignore if
-    if (isProcessing) { submitButtonState = 'processing'; }
+
+    const showLoadingButton = loading || isQuantityUpdating || !window.microform;
 
     return (
       <ErrorFocusContext.Provider value={this.state.firstErrorId}>
@@ -242,40 +239,12 @@ export class PaymentFormComponent extends React.Component {
           <CardDetails
             disabled={disabled}
           />
-          <div className="row justify-content-end">
-            <div className="col-lg-6 form-group">
-              {
-                loading || isQuantityUpdating || !window.microform ? (
-                  <div className="skeleton btn btn-block btn-lg">&nbsp;</div>
-                ) : (
-                  <StatefulButton
-                    type="submit"
-                    id="placeOrderButton"
-                    variant="primary"
-                    size="lg"
-                    block
-                    state={submitButtonState}
-                    onClick={this.props.onSubmitButtonClick}
-                    labels={{
-                      default: (
-                        <FormattedMessage
-                          id="payment.form.submit.button.text"
-                          defaultMessage="Place Order"
-                          description="The label for the payment form submit button"
-                        />
-                      ),
-                    }}
-                    icons={{
-                      processing: (
-                        <span className="button-spinner-icon" />
-                      ),
-                    }}
-                    disabledStates={['processing', 'disabled']}
-                  />
-                )
-              }
-            </div>
-          </div>
+          <PlaceOrderButton
+            onSubmitButtonClick={this.props.onSubmitButtonClick}
+            showLoadingButton={showLoadingButton}
+            disabled={disabled}
+            isProcessing={isProcessing}
+          />
         </form>
         )}
       </ErrorFocusContext.Provider>

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -3,20 +3,15 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { reduxForm, SubmissionError } from 'redux-form';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
-import { loadStripe } from '@stripe/stripe-js';
-import { Elements } from '@stripe/react-stripe-js';
 import { injectIntl } from '@edx/frontend-platform/i18n';
 
 import CardDetails from './CardDetails';
 import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
-import StripeCardPayment from './StripeCardPayment';
 import getStates from './utils/countryStatesMap';
 import { updateCaptureKeySelector, updateSubmitErrorsSelector } from '../../data/selectors';
 import { markPerformanceIfAble, getPerformanceProperties } from '../../performanceEventing';
 import { ErrorFocusContext } from './contexts';
-
-const stripePromise = loadStripe(process.env.STRIPE_PUBLISHABLE_KEY);
 
 export class PaymentFormComponent extends React.Component {
   constructor(props) {
@@ -201,32 +196,12 @@ export class PaymentFormComponent extends React.Component {
       isProcessing,
       isBulkOrder,
       isQuantityUpdating,
-      enableStripePaymentProcessor,
     } = this.props;
-
-    // Stripe element config
-    // TODO: Move these to a better home
-    const appearance = {
-      theme: 'stripe',
-    };
-    const options = {
-      clientSecret: this.props.captureKeyId,
-      appearance,
-    };
 
     const showLoadingButton = loading || isQuantityUpdating || !window.microform;
 
     return (
       <ErrorFocusContext.Provider value={this.state.firstErrorId}>
-        {enableStripePaymentProcessor && options.clientSecret && (
-          <Elements options={options} stripe={stripePromise}>
-            <StripeCardPayment clientSecret={options.clientSecret} disabled={disabled} isBulkOrder={isBulkOrder} />
-            {/* onSubmitButtonClick={this.props.onSubmitButtonClick}
-            onSubmitPayment={this.props.onSubmitPayment} */}
-          </Elements>
-        )}
-
-        {!enableStripePaymentProcessor && (
         <form
           onSubmit={handleSubmit(this.onSubmit)}
           ref={this.formRef}
@@ -246,7 +221,6 @@ export class PaymentFormComponent extends React.Component {
             isProcessing={isProcessing}
           />
         </form>
-        )}
       </ErrorFocusContext.Provider>
     );
   }
@@ -262,8 +236,6 @@ PaymentFormComponent.propTypes = {
   onSubmitPayment: PropTypes.func.isRequired,
   onSubmitButtonClick: PropTypes.func.isRequired,
   submitErrors: PropTypes.objectOf(PropTypes.string),
-  captureKeyId: PropTypes.string,
-  enableStripePaymentProcessor: PropTypes.bool,
 };
 
 PaymentFormComponent.defaultProps = {
@@ -273,8 +245,6 @@ PaymentFormComponent.defaultProps = {
   isQuantityUpdating: false,
   isProcessing: false,
   submitErrors: {},
-  captureKeyId: null,
-  enableStripePaymentProcessor: false,
 };
 
 const mapStateToProps = (state) => {

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -201,7 +201,7 @@ export class PaymentFormComponent extends React.Component {
       isProcessing,
       isBulkOrder,
       isQuantityUpdating,
-      stripeEnabled,
+      enableStripePaymentProcessor,
     } = this.props;
 
     // Stripe element config
@@ -221,7 +221,7 @@ export class PaymentFormComponent extends React.Component {
 
     return (
       <ErrorFocusContext.Provider value={this.state.firstErrorId}>
-        {stripeEnabled && options.clientSecret && (
+        {enableStripePaymentProcessor && options.clientSecret && (
           <Elements options={options} stripe={stripePromise}>
             <StripeCardPayment clientSecret={options.clientSecret} disabled={disabled} isBulkOrder={isBulkOrder} />
             {/* onSubmitButtonClick={this.props.onSubmitButtonClick}
@@ -229,7 +229,7 @@ export class PaymentFormComponent extends React.Component {
           </Elements>
         )}
 
-        {!stripeEnabled && (
+        {!enableStripePaymentProcessor && (
         <form
           onSubmit={handleSubmit(this.onSubmit)}
           ref={this.formRef}
@@ -294,7 +294,7 @@ PaymentFormComponent.propTypes = {
   onSubmitButtonClick: PropTypes.func.isRequired,
   submitErrors: PropTypes.objectOf(PropTypes.string),
   captureKeyId: PropTypes.string,
-  stripeEnabled: PropTypes.bool,
+  enableStripePaymentProcessor: PropTypes.bool,
 };
 
 PaymentFormComponent.defaultProps = {
@@ -305,7 +305,7 @@ PaymentFormComponent.defaultProps = {
   isProcessing: false,
   submitErrors: {},
   captureKeyId: null,
-  stripeEnabled: true,
+  enableStripePaymentProcessor: false,
 };
 
 const mapStateToProps = (state) => {

--- a/src/payment/checkout/payment-form/PlaceOrderButton.jsx
+++ b/src/payment/checkout/payment-form/PlaceOrderButton.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { StatefulButton } from '@edx/paragon';
+
+function PlaceOrderButton({
+  showLoadingButton, onSubmitButtonClick, disabled, isProcessing,
+}) {
+  let submitButtonState = 'default';
+  // istanbul ignore if
+  if (disabled) { submitButtonState = 'disabled'; }
+  // istanbul ignore if
+  if (isProcessing) { submitButtonState = 'processing'; }
+
+  return (
+    <div className="col-lg-6 form-group">
+      <div className="row justify-content-end">
+        {
+        showLoadingButton ? (
+          <div className="skeleton btn btn-block btn-lg">&nbsp;</div>
+        ) : (
+          <StatefulButton
+            type="submit"
+            id="placeOrderButton"
+            variant="primary"
+            size="lg"
+            block
+            state={submitButtonState}
+            onClick={onSubmitButtonClick}
+            labels={{
+              default: (
+                <FormattedMessage
+                  id="payment.form.submit.button.text"
+                  defaultMessage="Place Order"
+                  description="The label for the payment form submit button"
+                />
+              ),
+            }}
+            icons={{
+              processing: (
+                <span className="button-spinner-icon" />
+              ),
+            }}
+            disabledStates={['processing', 'disabled']}
+          />
+        )
+    }
+      </div>
+    </div>
+  );
+}
+
+PlaceOrderButton.propTypes = {
+  onSubmitButtonClick: PropTypes.func.isRequired,
+  showLoadingButton: PropTypes.bool,
+  disabled: PropTypes.bool,
+  isProcessing: PropTypes.bool,
+};
+
+PlaceOrderButton.defaultProps = {
+  showLoadingButton: false,
+  disabled: false,
+  isProcessing: false,
+};
+
+export default injectIntl(PlaceOrderButton);

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -12,7 +12,7 @@ import { AppContext } from '@edx/frontend-platform/react';
 import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
 // onSubmitPayment, onSubmitButtonClick
-function StripeCardPayment({
+function StripePaymentForm({
   clientSecret, disabled, handleSubmit, isBulkOrder, loading, isQuantityUpdating, isProcessing, onSubmitButtonClick,
 }) {
   const stripe = useStripe();
@@ -143,7 +143,7 @@ function StripeCardPayment({
   );
 }
 
-StripeCardPayment.propTypes = {
+StripePaymentForm.propTypes = {
   clientSecret: PropTypes.string,
   disabled: PropTypes.bool,
   handleSubmit: PropTypes.func.isRequired,
@@ -154,7 +154,7 @@ StripeCardPayment.propTypes = {
   onSubmitButtonClick: PropTypes.func.isRequired,
 };
 
-StripeCardPayment.defaultProps = {
+StripePaymentForm.defaultProps = {
   clientSecret: null,
   disabled: false,
   isBulkOrder: false,
@@ -163,4 +163,4 @@ StripeCardPayment.defaultProps = {
   isProcessing: false,
 };
 
-export default reduxForm({ form: 'stripe' })(StripeCardPayment);
+export default reduxForm({ form: 'stripe' })(StripePaymentForm);


### PR DESCRIPTION
[REV-3001](https://2u-internal.atlassian.net/browse/REV-3001).

Refactoring the Stripe component so that it becomes of sibling of the PaymentForm (used for CyberSource) removing one layer of the component hierarchy. Also took out the submit button to its own component so that it can be used for both CyberSource form and Stripe form.

Made a successful test payment with this refactor - 
<img width="1157" alt="Screen Shot 2022-10-05 at 1 50 06 PM" src="https://user-images.githubusercontent.com/13632680/194130014-0f780abb-f8c8-4a9c-a44a-e6ccfd7eec56.png">

**This PR:**
- Fixes the temp `true` on the `enableStripePaymentProcessor` flag value to use the actual waffle flag value from ecommerce Basket API.
- Moves the place order button to its own component for reusability in both CyberSource and Stripe payment forms.
- Moves the `StripeCardPayment` component to be its own component separate from `PaymentForm` (since it has its own form, it did not need to be in the PaymentForm component, removing one unnecessary child --> `PaymentForm` and `StripeCardPayment` will be siblings).
- Renames the `StripeCardPayment` component to `StripePaymentForm`

**How to test this locally:**
1. Checkout this branch
2. Make sure you run `make dev.down.frontend-app-payment` in your `/devstack` directory
3. On `frontend-app-payment` run `npm ci` + `npm start`
4. Enroll in a course and upgrade
5. Billing address form should load, as well as the Stripe card elements
6. Make a purchase and see the receipt page