### PR TITLE
fix: follow redirect sent by ecommerce on successful stripe payment

### DIFF
--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -103,6 +103,14 @@ function StripePaymentForm({
               headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             },
           )
+          .then(response => {
+            // TODO: This hits the receipt page twice, but Axios doesn't seem
+            // to support maxRedirects outside of NodeJS. Need to shift to a
+            // way that does not make two calls.
+            if (response.headers['content-type'].startsWith('text/html')) {
+              global.location.href = response.request.responseURL;
+            }
+          })
           .catch(error => {
             console.log('[Project Zebra] POST error: ', error.message);
           });


### PR DESCRIPTION
## Description

This PR fixes a bug where the user is not redirected to the receipt page after a successful purchase.

This is a bit of a hack because the receipt page is hit twice. Tried using Axios' maxRedirects = 0, but that still did not catch the redirect.

## Additional information

* Jira: [REV-3100](https://2u-internal.atlassian.net/browse/REV-3100)