### PR TITLE
fix: false alerts and errors for stripe removed

### DIFF
--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -8,10 +8,10 @@ import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import messages from './PaymentPage.messages';
 
 // Actions
-import { fetchBasket, fetchCaptureKey, fetchClientSecret } from './data/actions';
+import { fetchBasket, fetchClientSecret } from './data/actions';
 
 // Selectors
-import { paymentSelector, updateCaptureKeySelector, updateClientSecretSelector } from './data/selectors';
+import { paymentSelector, updateClientSecretSelector } from './data/selectors';
 
 // Components
 import PageLoading from './PageLoading';
@@ -51,7 +51,6 @@ class PaymentPage extends React.Component {
   componentDidMount() {
     sendPageEvent();
     this.props.fetchBasket();
-    this.props.fetchCaptureKey();
     this.props.fetchClientSecret();
   }
 
@@ -141,7 +140,6 @@ class PaymentPage extends React.Component {
             'transaction-declined-message': (
               <TransactionDeclined />
             ),
-            /* TODO: should not render when using Stripe, likely need to refactor handleFetchCaptureKey */
             'capture-key-2mins-message': (
               <CaptureKeyTimeoutTwoMinutes />
             ),
@@ -165,7 +163,6 @@ PaymentPage.propTypes = {
   isEmpty: PropTypes.bool,
   isRedirect: PropTypes.bool,
   fetchBasket: PropTypes.func.isRequired,
-  fetchCaptureKey: PropTypes.func.isRequired,
   fetchClientSecret: PropTypes.func.isRequired,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
@@ -180,7 +177,6 @@ PaymentPage.defaultProps = {
 
 const mapStateToProps = (state) => ({
   ...paymentSelector(state),
-  ...updateCaptureKeySelector(state),
   ...updateClientSecretSelector(state),
 });
 
@@ -188,7 +184,6 @@ export default connect(
   mapStateToProps,
   {
     fetchBasket,
-    fetchCaptureKey,
     fetchClientSecret,
   },
 )(injectIntl(PaymentPage));

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -8,7 +8,7 @@ import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import messages from './Checkout.messages';
-import { paymentSelector, updateCaptureKeySelector, updateClientSecretSelector } from '../data/selectors';
+import { paymentSelector, updateClientSecretSelector } from '../data/selectors';
 import { submitPayment } from '../data/actions';
 import AcceptedCardLogos from './assets/accepted-card-logos.png';
 
@@ -222,7 +222,6 @@ class Checkout extends React.Component {
             <StripePaymentForm
               onSubmitPayment={this.handleSubmitStripe}
               onSubmitButtonClick={this.handleSubmitStripeButtonClick}
-              clientSecret={options.clientSecret}
               disabled={submitting}
               isBulkOrder={isBulkOrder}
               isProcessing={stripeIsSubmitting}
@@ -289,7 +288,6 @@ Checkout.defaultProps = {
 
 const mapStateToProps = (state) => ({
   ...paymentSelector(state),
-  ...updateCaptureKeySelector(state),
   ...updateClientSecretSelector(state),
 });
 

--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -10,6 +10,7 @@ import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
 import getStates from './utils/countryStatesMap';
 import { updateCaptureKeySelector, updateSubmitErrorsSelector } from '../../data/selectors';
+import { fetchCaptureKey } from '../../data/actions';
 import { markPerformanceIfAble, getPerformanceProperties } from '../../performanceEventing';
 import { ErrorFocusContext } from './contexts';
 
@@ -29,6 +30,7 @@ export class PaymentFormComponent extends React.Component {
       'edx.bi.ecommerce.payment_mfe.payment_form_rendered',
       getPerformanceProperties(),
     );
+    this.props.fetchCaptureKey();
   }
 
   componentDidUpdate() {
@@ -236,6 +238,7 @@ PaymentFormComponent.propTypes = {
   onSubmitPayment: PropTypes.func.isRequired,
   onSubmitButtonClick: PropTypes.func.isRequired,
   submitErrors: PropTypes.objectOf(PropTypes.string),
+  fetchCaptureKey: PropTypes.func.isRequired,
 };
 
 PaymentFormComponent.defaultProps = {
@@ -257,4 +260,9 @@ const mapStateToProps = (state) => {
 
 // The key `form` here needs to match the key provided to
 // combineReducers when setting up the form reducer.
-export default reduxForm({ form: 'payment' })(connect(mapStateToProps)(injectIntl(PaymentFormComponent)));
+export default reduxForm({ form: 'payment' })(connect(
+  mapStateToProps,
+  {
+    fetchCaptureKey,
+  },
+)(injectIntl(PaymentFormComponent)));

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { reduxForm } from 'redux-form';
 import formurlencoded from 'form-urlencoded';
 import PropTypes from 'prop-types';
@@ -15,7 +15,7 @@ import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
 
 function StripePaymentForm({
-  clientSecret, disabled, handleSubmit, isBulkOrder, loading, isQuantityUpdating, isProcessing, onSubmitButtonClick,
+  disabled, handleSubmit, isBulkOrder, loading, isQuantityUpdating, isProcessing, onSubmitButtonClick,
 }) {
   const stripe = useStripe();
   const elements = useElements();
@@ -27,33 +27,6 @@ function StripePaymentForm({
   // TODO: bug on loading state, showLoadingButton is true before Stripe card detail is fully rendered
   // TODO: rename to distinguish loading of data and loading of card details
   const showLoadingButton = loading || isQuantityUpdating || isLoading || !stripe || !elements;
-
-  useEffect(() => {
-    if (!stripe) {
-      return;
-    }
-
-    if (!clientSecret) {
-      return;
-    }
-
-    stripe.retrievePaymentIntent(clientSecret).then(({ paymentIntent }) => {
-      switch (paymentIntent.status) {
-        case 'succeeded':
-          setMessage('Payment succeeded!');
-          break;
-        case 'processing':
-          setMessage('Your payment is processing.');
-          break;
-        case 'requires_payment_method':
-          setMessage('Your payment was not successful, please try again.');
-          break;
-        default:
-          setMessage('Something went wrong.');
-          break;
-      }
-    });
-  }, [stripe, clientSecret]);
 
   const onSubmit = async (values) => {
     // istanbul ignore if
@@ -79,7 +52,7 @@ function StripePaymentForm({
       // Make sure to disable form submission until Stripe.js has loaded.
       return;
     }
-
+    setMessage('');
     setIsLoading(true);
 
     const stripePaymentMethodHandler = async (result) => {
@@ -169,7 +142,6 @@ function StripePaymentForm({
 }
 
 StripePaymentForm.propTypes = {
-  clientSecret: PropTypes.string,
   disabled: PropTypes.bool,
   handleSubmit: PropTypes.func.isRequired,
   isBulkOrder: PropTypes.bool,
@@ -180,7 +152,6 @@ StripePaymentForm.propTypes = {
 };
 
 StripePaymentForm.defaultProps = {
-  clientSecret: null,
   disabled: false,
   isBulkOrder: false,
   loading: false,


### PR DESCRIPTION
[REV-3057](https://2u-internal.atlassian.net/browse/REV-3057)

This pull request moves the capture context to be within the cybersource elements to prevent the cybersource timeout alerts from starting.

It also remove the useEffect on the stripe elements for setting the message since as of the custom actions beta we now use ecommerce to contact stripe instead of directly from the frontend