### PR TITLE
fix: Add trailing slash to STRIPE_RESPONSE_URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -32,4 +32,4 @@ APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit',
 STRIPE_API_VERSION=2022-08-01;server_side_confirmation_beta=v1
 STRIPE_BETA_FLAG=server_side_confirmation_beta_1
 STRIPE_PUBLISHABLE_KEY=null
-STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout/

--- a/.env.development-stage
+++ b/.env.development-stage
@@ -32,4 +32,4 @@ APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit'
 STRIPE_API_VERSION=2022-08-01;server_side_confirmation_beta=v1
 STRIPE_BETA_FLAG=server_side_confirmation_beta_1
 STRIPE_PUBLISHABLE_KEY=null
-STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout/

--- a/.env.test
+++ b/.env.test
@@ -32,4 +32,4 @@ APPLE_PAY_MERCHANT_CAPABILITIES='supports3DS,supportsCredit,supportsDebit',
 STRIPE_API_VERSION=2022-08-01;server_side_confirmation_beta=v1
 STRIPE_BETA_FLAG=server_side_confirmation_beta_1
 STRIPE_PUBLISHABLE_KEY=null
-STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout
+STRIPE_RESPONSE_URL=http://localhost:18130/payment/stripe/checkout/


### PR DESCRIPTION
[REV-3105](https://2u-internal.atlassian.net/browse/REV-3105).

We're seeing a CORS preflight error with a 302 redirect when attempting to purchase in Stage for project Zebra.
https://github.com/edx/edx-internal/pull/7282 added the trailing `/` to the response URL in an attempt to fix this issue, so adding this here as well.

Pls note that the trailing slash did not fix the CORS issue (`ecommerce` does not have it in the stripe URL), but merging this for consistency with `edx-internal` URLs. The presence of the slash does not break it.

`
Access to XMLHttpRequest at 'https://ecommerce.stage.edx.org/login/?next=/payment/stripe/checkout' (redirected from 'https://ecommerce.stage.edx.org/payment/stripe/checkout') from origin 'https://payment.stage.edx.org/' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a preflight request.`