### PR TITLE
fix: dont display confirm payment button until stripe has loaded

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,7 +1,8 @@
 {
     "allowlist": [
         "GHSA-44c6-4v22-4mhx",
-        "GHSA-pfrx-2q88-qq97"
+        "GHSA-pfrx-2q88-qq97",
+        "GHSA-f8q6-p94x-37v3"
     ],
     "moderate": true
 }

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -29,7 +29,6 @@ function StripePaymentForm({
   const [message, setMessage] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // TODO: bug on loading state, showLoadingButton is true before Stripe card detail is fully rendered
   // TODO: rename to distinguish loading of data and loading of card details
   const showLoadingButton = loading || isQuantityUpdating || isLoading || !stripe || !elements;
 

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -27,7 +27,7 @@ function StripePaymentForm({
 
   const context = useContext(AppContext);
   const [message, setMessage] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // TODO: bug on loading state, showLoadingButton is true before Stripe card detail is fully rendered
   // TODO: rename to distinguish loading of data and loading of card details
@@ -164,7 +164,10 @@ function StripePaymentForm({
           description="The heading for the credit card details billing information form"
         />
       </h5>
-      <PaymentElement id="payment-element" />
+      <PaymentElement
+        id="payment-element"
+        onReady={() => setIsLoading(false)}
+      />
       <PlaceOrderButton
         onSubmitButtonClick={onSubmitButtonClick}
         showLoadingButton={showLoadingButton}


### PR DESCRIPTION
[REV-3107](https://2u-internal.atlassian.net/browse/REV-3107)

This PR hides the pay now button for Stripe payment processor until the Stripe elements have loaded.

It also adds [GHSA-f8q6-p94x-37v3](https://github.com/advisories/GHSA-f8q6-p94x-37v3) to the audit allow list
