### PR TITLE
fix: add ISSUE_ERROR Redux action to call <FallbackErrorMessage>

### DIFF
--- a/src/payment/data/actions.js
+++ b/src/payment/data/actions.js
@@ -19,6 +19,7 @@ export const fetchBasket = createRoutine('FETCH_BASKET');
 export const addCoupon = createRoutine('ADD_COUPON');
 export const removeCoupon = createRoutine('REMOVE_COUPON');
 export const updateQuantity = createRoutine('UPDATE_QUANTITY');
+export const issueError = createRoutine('ISSUE_ERROR');
 
 // Actions and their action creators
 export const BASKET_DATA_RECEIVED = 'BASKET_DATA_RECEIVED';
@@ -74,3 +75,5 @@ export const clientSecretDataReceived = clientSecret => ({
   type: CLIENT_SECRET_DATA_RECEIVED,
   payload: clientSecret,
 });
+
+export const ISSUE_ERROR = 'ISSUE_ERROR';

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -23,6 +23,7 @@ import {
   fetchCaptureKey,
   clientSecretProcessing,
   fetchClientSecret,
+  issueError,
 } from './actions';
 
 import { STATUS_LOADING } from '../checkout/payment-form/flex-microform/constants';
@@ -269,6 +270,11 @@ export function* handleSubmitPayment({ payload }) {
   }
 }
 
+export function* handleIssueError() {
+  // Show generic <FallbackErrorMessage>
+  yield call(handleErrors, {}, true);
+}
+
 export default function* saga() {
   yield takeEvery(fetchCaptureKey.TRIGGER, handleFetchCaptureKey);
   yield takeEvery(CAPTURE_KEY_START_TIMEOUT, handleCaptureKeyTimeout);
@@ -278,4 +284,5 @@ export default function* saga() {
   yield takeEvery(removeCoupon.TRIGGER, handleRemoveCoupon);
   yield takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity);
   yield takeEvery(submitPayment.TRIGGER, handleSubmitPayment);
+  yield takeEvery(issueError.TRIGGER, handleIssueError);
 }

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -15,6 +15,7 @@ import paymentSaga, {
   handleFetchCaptureKey,
   handleCaptureKeyTimeout,
   handleFetchClientSecret,
+  handleIssueError,
 } from './sagas';
 import { transformResults } from './service';
 import {
@@ -28,6 +29,7 @@ import {
   submitPayment,
   CAPTURE_KEY_START_TIMEOUT,
   fetchClientSecret,
+  issueError,
 } from './actions';
 import { clearMessages, MESSAGE_TYPES, addMessage } from '../../feedback';
 
@@ -745,6 +747,7 @@ describe('saga tests', () => {
     expect(gen.next().value).toEqual(takeEvery(removeCoupon.TRIGGER, handleRemoveCoupon));
     expect(gen.next().value).toEqual(takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity));
     expect(gen.next().value).toEqual(takeEvery(submitPayment.TRIGGER, handleSubmitPayment));
+    expect(gen.next().value).toEqual(takeEvery(issueError.TRIGGER, handleIssueError));
 
     // If you find yourself adding something here, there are probably more tests to write!
 


### PR DESCRIPTION
## Description

Currently, after pressing the checkout button, `<StripePaymentForm>` does not show any error message if the ecommerce backend throws a generic error.

This PR adds a trigger of `<FallbackErrorMessage>` for when the generic error is thrown.

The correct thing to do would have to move all the state logic in `<StripePaymentForm>` into Redux. Due to time constraints, I am implementing a hack, which is bringing Redux to `<StripePaymentForm>`.

This PR also calls `setIsLoading(false);` after the checkout button errors are handled so the user can try to re-submit if necessary.

## Supporting information

* Jira:
  * Discovered via [REV-3117](https://2u-internal.atlassian.net/browse/REV-3117) "Stage: A specific declined payment use case results in "Place order" button  stuck, page not showing any error."
  * Implements [REV-3123](https://2u-internal.atlassian.net/browse/REV-3123) "Stage: No pink error banner when attempting to buy same basket in the second tab"
* Special thanks to @grmartin for the linter fix!

## Testing instructions

* On local:
  * [X] Test purchase with decline card shows error
  * [X] Test purchase after card decline with good card is successful
* On stage:
  * [X] QA team assigned to repeat local testing on stage.
* On prod:
  * [X] QA team assigned to repeat stage testing on prod.

## Checklist
- [X] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [X] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
