### PR TITLE
fix: Change zip code field to be required for Stripe for certain countries

### DIFF
--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -2045,6 +2045,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   onDragStart={[Function]}
                   onDrop={[Function]}
                   onFocus={[Function]}
+                  required={false}
                   type="text"
                   value=""
                 />
@@ -4057,6 +4058,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   onDragStart={[Function]}
                   onDrop={[Function]}
                   onFocus={[Function]}
+                  required={false}
                   type="text"
                   value=""
                 />
@@ -5975,6 +5977,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   onDragStart={[Function]}
                   onDrop={[Function]}
                   onFocus={[Function]}
+                  required={false}
                   type="text"
                   value=""
                 />
@@ -7870,6 +7873,7 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   onDragStart={[Function]}
                   onDrop={[Function]}
                   onFocus={[Function]}
+                  required={false}
                   type="text"
                   value=""
                 />

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -222,6 +222,7 @@ class Checkout extends React.Component {
               isProcessing={stripeIsSubmitting}
               loading={loading}
               isQuantityUpdating={isQuantityUpdating}
+              enableStripePaymentProcessor={enableStripePaymentProcessor}
             />
           </Elements>
         ) : (loading && (this.renderBillingFormSkeleton()))}

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -212,6 +212,11 @@ class Checkout extends React.Component {
           </p>
         </div>
 
+        {/* Passing the enableStripePaymentProcessor flag down the Stripe form component to
+        be used in the CardHolderInformation component (child). We could get the flag value
+        from Basket selector from the child component but this would require more change for a temp feature,
+        since the flag will not be needed when we remove CyberSource.
+        This is not needed in CyberSource form component since the default is set to false. */}
         {shouldDisplayStripePaymentForm ? (
           <Elements options={options} stripe={stripePromise}>
             <StripePaymentForm

--- a/src/payment/checkout/payment-form/CardHolderInformation.jsx
+++ b/src/payment/checkout/payment-form/CardHolderInformation.jsx
@@ -25,6 +25,32 @@ export class CardHolderInformationComponent extends React.Component {
     this.props.clearFields('payment', false, false, ['state']);
   };
 
+  handlePostalCodeLabel() {
+    if (this.isPostalCodeRequired()) {
+      return (
+        <FormattedMessage
+          id="payment.card.holder.information.postal.code.label.required"
+          defaultMessage="Zip/Postal Code (required)"
+          description="The label for the card holder zip/postal code field (required)"
+        />
+      );
+    }
+    return (
+      <FormattedMessage
+        id="payment.card.holder.information.postal.code.label"
+        defaultMessage="Zip/Postal Code"
+        description="The label for the card holder zip/postal code field"
+      />
+    );
+  }
+
+  isPostalCodeRequired() {
+    const countryListRequiredPostalCode = ['CA', 'GB', 'US'];
+    const postalCodeRequired = countryListRequiredPostalCode.includes(this.state.selectedCountry)
+    && this.props.enableStripePaymentProcessor;
+    return postalCodeRequired;
+  }
+
   renderCountryOptions() {
     const items = [(
       <option key="" value="">
@@ -207,11 +233,7 @@ export class CardHolderInformationComponent extends React.Component {
           </div>
           <div className="col-lg-6 form-group">
             <label htmlFor="postalCode">
-              <FormattedMessage
-                id="payment.card.holder.information.postal.code.label"
-                defaultMessage="Zip/Postal Code"
-                description="The label for the card holder zip/postal code field"
-              />
+              {this.handlePostalCodeLabel()}
             </label>
             <Field
               id="postalCode"
@@ -221,6 +243,7 @@ export class CardHolderInformationComponent extends React.Component {
               disabled={disabled}
               autoComplete="postal-code"
               maxLength="9"
+              required={this.isPostalCodeRequired()}
             />
           </div>
         </div>
@@ -257,11 +280,13 @@ CardHolderInformationComponent.propTypes = {
   clearFields: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   disabled: PropTypes.bool,
+  enableStripePaymentProcessor: PropTypes.bool,
   showBulkEnrollmentFields: PropTypes.bool,
 };
 
 CardHolderInformationComponent.defaultProps = {
   disabled: false,
+  enableStripePaymentProcessor: false,
   showBulkEnrollmentFields: false,
 };
 

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -189,7 +189,7 @@ StripePaymentForm.propTypes = {
 
 StripePaymentForm.defaultProps = {
   disabled: false,
-  enableStripePaymentProcessor: false,
+  enableStripePaymentProcessor: true,
   isBulkOrder: false,
   loading: false,
   isQuantityUpdating: false,

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -22,6 +22,7 @@ import PlaceOrderButton from './PlaceOrderButton';
 
 function StripePaymentForm({
   disabled,
+  enableStripePaymentProcessor,
   handleSubmit,
   isBulkOrder,
   loading,
@@ -148,6 +149,7 @@ function StripePaymentForm({
       <CardHolderInformation
         showBulkEnrollmentFields={isBulkOrder}
         disabled={disabled}
+        enableStripePaymentProcessor={enableStripePaymentProcessor}
       />
       <h5 aria-level="2">
         <FormattedMessage
@@ -174,6 +176,7 @@ function StripePaymentForm({
 
 StripePaymentForm.propTypes = {
   disabled: PropTypes.bool,
+  enableStripePaymentProcessor: PropTypes.bool,
   handleSubmit: PropTypes.func.isRequired,
   isBulkOrder: PropTypes.bool,
   loading: PropTypes.bool,
@@ -186,6 +189,7 @@ StripePaymentForm.propTypes = {
 
 StripePaymentForm.defaultProps = {
   disabled: false,
+  enableStripePaymentProcessor: false,
   isBulkOrder: false,
   loading: false,
   isQuantityUpdating: false,

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -129,7 +129,7 @@ function StripePaymentForm({
               line1: address,
               line2: unit || '',
               postal_code: postalCode || '',
-              state,
+              state: state || '',
             },
             email: context.authenticatedUser.email,
             name: `${firstName} ${lastName}`,


### PR DESCRIPTION
[REV-3064](https://2u-internal.atlassian.net/browse/REV-3064).

When we disable the `billingDetails` for the Payment Element form from Stripe, it still expects ALL of the fields when we call `updatePaymentIntent` to send the POST data to Stripe, even though if we use the default settings for the Payment Element form, it does not include fields such as State, Phone, and Zip Code for the majority of the countries.

<img width="980" alt="Screen Shot 2022-10-27 at 5 34 48 PM" src="https://user-images.githubusercontent.com/13632680/198402780-cc2f0ca9-4c13-4a68-9d95-cf9693fcce86.png">

As a workaround, we're sending `''` if the value is `undefined` -> this is yet to be confirmed by Stripe if it will cause any issues, for example, in how much the credit card company will charge us if we have less data.
We can also make the Zip Code required to follow Stripe's forms for certain countries.

**This PR:**
- If Stripe is enabled, and if the countries selected are USA, Canada, and UK, we make the Zip Code field required. 
- For the field label, we have to have separate messages with separate IDs to avoid confusion with i18n.
- Send `''` if state is undefined, since state should be an optional field. State is a requirement on our end for USA, Canada, and India.

<img width="1023" alt="Screen Shot 2022-10-27 at 5 02 20 PM" src="https://user-images.githubusercontent.com/13632680/198400703-aac035a7-5a77-432b-a46f-283e35e5e315.png">

**Tests:** 
Testing Stripe payment flow without State and Zip Code, got a receipt page - 
<img width="1168" alt="Screen Shot 2022-10-28 at 12 32 55 PM" src="https://user-images.githubusercontent.com/13632680/198687506-70696d0e-0462-41ed-afbb-91d09515c0d8.png">

Testing Stripe payment flow with a Zip Code in a number format in the UK (Great Britain, aka GB) - 
https://dashboard.stripe.com/test/logs/req_0GGOAltMp5wgjA
https://dashboard.stripe.com/test/payments/pi_3LxveSIadiFyUl1x0NuLA4dG

Testing CyberSource payment flow to make sure Zip Code field does not show as "required" - 
This does not change the CyberSource payment form, tested below - 
<img width="1029" alt="Screen Shot 2022-10-28 at 11 38 15 AM" src="https://user-images.githubusercontent.com/13632680/198678713-7d9f4eb4-4997-4896-85ef-f009dc0c8c78.png">
