### PR TITLE
Revert "Revert "temp!: temporarily required ascii characters in name fields""

### DIFF
--- a/src/payment/checkout/payment-form/PaymentForm.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.jsx
@@ -59,6 +59,10 @@ export class PaymentFormComponent extends React.Component {
 
     const errors = {
       ...this.validateRequiredFields(requiredFields),
+      ...this.validateAsciiNames(
+        firstName,
+        lastName,
+      ),
       ...this.validateCardDetails(
         cardExpirationMonth,
         cardExpirationYear,
@@ -134,6 +138,20 @@ export class PaymentFormComponent extends React.Component {
       && parseInt(cardExpirationYear, 10) === currentYear
     ) {
       errors.cardExpirationMonth = 'payment.form.errors.card.expired';
+    }
+
+    return errors;
+  }
+
+  validateAsciiNames(firstName, lastName) {
+    const errors = {};
+
+    if (
+      firstName
+      && lastName
+      && !/[A-Za-z]/.test(firstName + lastName)
+    ) {
+      errors.firstName = 'payment.form.errors.ascii.name';
     }
 
     return errors;

--- a/src/payment/checkout/payment-form/PaymentForm.messages.jsx
+++ b/src/payment/checkout/payment-form/PaymentForm.messages.jsx
@@ -26,6 +26,11 @@ const messages = defineMessages({
     defaultMessage: 'This field is required',
     description: 'The form field feedback text for missing required field error.',
   },
+  'payment.form.errors.ascii.name': {
+    id: 'payment.form.errors.ascii.name',
+    defaultMessage: 'We apologize for the inconvenience but for the time being we require ASCII characters in the name field. We are working on addressing this and appreciate your patience.',
+    description: 'The form field feedback text for name format issue.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
Reverts openedx/frontend-app-payment#553

Reverting the revert! Adding back the form validation for non-ASCII characters (first and last name only) on the CyberSource flow, as per the discussion in https://2u-internal.atlassian.net/browse/REV-3148, we will be adding this same validation for the Stripe payment flow as well, as a workaround to the gov's API bug.