### PR TITLE
fix: Move fetchClientSecret away from basket call on payment page load

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,7 +2,8 @@
     "allowlist": [
         "GHSA-44c6-4v22-4mhx",
         "GHSA-pfrx-2q88-qq97",
-        "GHSA-f8q6-p94x-37v3"
+        "GHSA-f8q6-p94x-37v3",
+        "GHSA-76p3-8jx3-jpfq"
     ],
     "moderate": true
 }

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -8,10 +8,10 @@ import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import messages from './PaymentPage.messages';
 
 // Actions
-import { fetchBasket, fetchClientSecret } from './data/actions';
+import { fetchBasket } from './data/actions';
 
 // Selectors
-import { paymentSelector, updateClientSecretSelector } from './data/selectors';
+import { paymentSelector } from './data/selectors';
 
 // Components
 import PageLoading from './PageLoading';
@@ -51,7 +51,6 @@ class PaymentPage extends React.Component {
   componentDidMount() {
     sendPageEvent();
     this.props.fetchBasket();
-    this.props.fetchClientSecret();
   }
 
   renderContent() {
@@ -163,7 +162,6 @@ PaymentPage.propTypes = {
   isEmpty: PropTypes.bool,
   isRedirect: PropTypes.bool,
   fetchBasket: PropTypes.func.isRequired,
-  fetchClientSecret: PropTypes.func.isRequired,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
 };
@@ -177,13 +175,6 @@ PaymentPage.defaultProps = {
 
 const mapStateToProps = (state) => ({
   ...paymentSelector(state),
-  ...updateClientSecretSelector(state),
 });
 
-export default connect(
-  mapStateToProps,
-  {
-    fetchBasket,
-    fetchClientSecret,
-  },
-)(injectIntl(PaymentPage));
+export default connect(mapStateToProps, { fetchBasket })(injectIntl(PaymentPage));

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -14,7 +14,7 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import messages from './Checkout.messages';
 import { paymentSelector, updateClientSecretSelector } from '../data/selectors';
-import { submitPayment } from '../data/actions';
+import { fetchClientSecret, submitPayment } from '../data/actions';
 import AcceptedCardLogos from './assets/accepted-card-logos.png';
 
 import PaymentForm from './payment-form/PaymentForm';
@@ -24,6 +24,10 @@ import { PayPalButton } from '../payment-methods/paypal';
 import { ORDER_TYPES } from '../data/constants';
 
 class Checkout extends React.Component {
+  componentDidMount() {
+    this.props.fetchClientSecret();
+  }
+
   handleSubmitPayPal = () => {
     // TO DO: after event parity, track data should be
     // sent only if the payment is processed, not on click
@@ -287,6 +291,7 @@ Checkout.propTypes = {
   intl: intlShape.isRequired,
   loading: PropTypes.bool,
   loaded: PropTypes.bool,
+  fetchClientSecret: PropTypes.func.isRequired,
   submitPayment: PropTypes.func.isRequired,
   isFreeBasket: PropTypes.bool,
   submitting: PropTypes.bool,
@@ -314,4 +319,4 @@ const mapStateToProps = (state) => ({
   ...updateClientSecretSelector(state),
 });
 
-export default connect(mapStateToProps, { submitPayment })(injectIntl(Checkout));
+export default connect(mapStateToProps, { fetchClientSecret, submitPayment })(injectIntl(Checkout));


### PR DESCRIPTION
[REV-3157](https://2u-internal.atlassian.net/browse/REV-3157).

Previously, payment MFE would call `fetchClientSecret()` and `fetchBasket()` at the same level upon `PaymentPage` component load. This caused an issue because it’s at the `PaymentPage` level that `EmptyCartMessage` is loaded if the basket is empty - so it didn’t get the chance to know that the basket was empty before it called `fetchClientSecret()`.