### PR TITLE
fix: various accessibility and stripe styling fixes

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -3,7 +3,9 @@
         "GHSA-44c6-4v22-4mhx",
         "GHSA-pfrx-2q88-qq97",
         "GHSA-f8q6-p94x-37v3",
-        "GHSA-76p3-8jx3-jpfq"
+        "GHSA-76p3-8jx3-jpfq",
+        "GHSA-3rfm-jhwj-7488",
+        "GHSA-hhq3-ff78-jv3g"
     ],
     "moderate": true
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -72,7 +72,7 @@ subscribe(APP_READY, () => {
   ReactDOM.render(
     <AppProvider store={configureStore()}>
       <Header />
-      <main>
+      <main id="main">
         <Switch>
           <Route exact path="/" component={PaymentPage} />
           <Route path="*" component={EcommerceRedirect} />

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -159,6 +159,10 @@ class Checkout extends React.Component {
     const options = {
       clientSecret: this.props.clientSecretId,
       appearance: {
+        // Normally these styling values would come from Paragon,
+        // however since stripe requires styling to be passed
+        // in through the appearance object they are currently placed here.
+        // TODO: Investigate if these values can be pulled into javascript from the Paragon css files
         rules: {
           '.Input': {
             border: 'solid 1px #707070',

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -178,6 +178,10 @@ class Checkout extends React.Component {
             outline: '0',
             boxShadow: '0 0 0 1px #0A3055', // $primary
           },
+          '.Label': {
+            fontSize: '1.125rem',
+            marginBottom: '0.5rem',
+          },
         },
       },
       fields: {

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -156,12 +156,26 @@ class Checkout extends React.Component {
 
     // Stripe element config
     // TODO: Move these to a better home
-    const appearance = {
-      theme: 'stripe',
-    };
     const options = {
       clientSecret: this.props.clientSecretId,
-      appearance,
+      appearance: {
+        rules: {
+          '.Input': {
+            border: 'solid 1px #707070',
+            borderRadius: '0.375rem',
+          },
+          '.Input:hover': {
+            border: 'solid 1px #1f3226',
+          },
+          '.Input:focus': {
+            color: '#454545',
+            backgroundColor: '#FFFFFF',
+            borderColor: '#0A3055',
+            outline: '0',
+            boxShadow: '0 0 0 1px #0A3055',
+          },
+        },
+      },
       fields: {
         billingDetails: {
           address: 'never',

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -165,7 +165,7 @@ class Checkout extends React.Component {
         // TODO: Investigate if these values can be pulled into javascript from the Paragon css files
         rules: {
           '.Input': {
-            border: 'solid 1px #707070',
+            border: 'solid 1px #707070', // $gray-500
             borderRadius: '0.375rem',
           },
           '.Input:hover': {
@@ -173,10 +173,10 @@ class Checkout extends React.Component {
           },
           '.Input:focus': {
             color: '#454545',
-            backgroundColor: '#FFFFFF',
-            borderColor: '#0A3055',
+            backgroundColor: '#FFFFFF', // $white
+            borderColor: '#0A3055', // $primary
             outline: '0',
-            boxShadow: '0 0 0 1px #0A3055',
+            boxShadow: '0 0 0 1px #0A3055', // $primary
           },
         },
       },

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -218,7 +218,6 @@ function StripePaymentForm({
         id="payment-element"
         options={options}
         onReady={stripeElementsOnReady}
-        role="presentation"
       />
       <PlaceOrderButton
         onSubmitButtonClick={onSubmitButtonClick}

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -210,14 +210,15 @@ function StripePaymentForm({
       <h5 aria-level="2">
         <FormattedMessage
           id="payment.card.details.billing.information.heading"
-          defaultMessage="Billing Information"
-          description="The heading for the credit card details billing information form"
+          defaultMessage="Billing Information (Required)"
+          description="The heading for the required credit card details billing information form"
         />
       </h5>
       <PaymentElement
         id="payment-element"
         options={options}
         onReady={stripeElementsOnReady}
+        role="presentation"
       />
       <PlaceOrderButton
         onSubmitButtonClick={onSubmitButtonClick}


### PR DESCRIPTION
[REV-3152](https://2u-internal.atlassian.net/browse/REV-3152)

This story addresses a few different points:
1) updated main tag to allow the skipNav link to bring the user to the main content of the page instead of having to tab through the navigation at the top.

2)added role presentation to the stripe iFrame to prevent a tab stop at the end of the cvc

3/4) Added rules to the stripe appearance field to let the inputs match the rest of the inputs on the page:
<img width="842" alt="Screen Shot 2022-11-18 at 9 05 54 AM" src="https://user-images.githubusercontent.com/43426024/202723217-f29619bb-2fd5-41fc-8010-2422c3a69673.png">

5) Updated billing details label to express 'required'.  After speaking with Jeff Witt recommended that putting required at the header of the section instead of each field was a better solution