### PR TITLE
feat: pass product SKUs to the backend when making a purchase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
     - name: Build
       run: npm run build
 
-    - name: Run Whitelist Audit
-      run: npm run audit:whitelisted
+    - name: Run Allowlist Audit
+      run: npm run audit:allowlisted

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run lint && npm run audit:whitelisted
+npm run lint && npm run audit:allowlisted

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ transifex_temp = ./temp/babel-plugin-react-intl
 
 precommit:
 	npm run lint
-	npm run audit:whitelisted
+	npm run audit:allowlisted
 
 requirements:
 	npm install

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -4,8 +4,8 @@
         "GHSA-pfrx-2q88-qq97",
         "GHSA-f8q6-p94x-37v3",
         "GHSA-76p3-8jx3-jpfq",
-	"GHSA-3rfm-jhwj-7488",
-	"GHSA-hhq3-ff78-jv3g"
+        "GHSA-3rfm-jhwj-7488",
+        "GHSA-hhq3-ff78-jv3g"
     ],
     "moderate": true
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -3,7 +3,9 @@
         "GHSA-44c6-4v22-4mhx",
         "GHSA-pfrx-2q88-qq97",
         "GHSA-f8q6-p94x-37v3",
-        "GHSA-76p3-8jx3-jpfq"
+        "GHSA-76p3-8jx3-jpfq",
+	"GHSA-3rfm-jhwj-7488",
+	"GHSA-hhq3-ff78-jv3g"
     ],
     "moderate": true
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack && node create-apple-merchant-file.js",
-    "audit:whitelisted": "npx audit-ci --config audit-ci.json",
+    "audit:allowlisted": "npx audit-ci --config audit-ci.json",
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "lint": "fedx-scripts eslint . --ext .js,.jsx",
     "prepare": "husky install",

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -105,9 +105,7 @@ class PaymentPage extends React.Component {
           />
         </div>
         <div className="col-md-7 pl-md-5">
-          <Checkout
-            products={this.props.products}
-          />
+          <Checkout />
         </div>
       </div>
     );
@@ -166,7 +164,6 @@ PaymentPage.propTypes = {
   fetchBasket: PropTypes.func.isRequired,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
-  products: PropTypes.array, // eslint-disable-line react/forbid-prop-types,
 };
 
 PaymentPage.defaultProps = {
@@ -174,7 +171,6 @@ PaymentPage.defaultProps = {
   isRedirect: false,
   summaryQuantity: undefined,
   summarySubtotal: undefined,
-  products: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -105,7 +105,9 @@ class PaymentPage extends React.Component {
           />
         </div>
         <div className="col-md-7 pl-md-5">
-          <Checkout />
+          <Checkout
+            products={this.props.products}
+          />
         </div>
       </div>
     );
@@ -164,6 +166,7 @@ PaymentPage.propTypes = {
   fetchBasket: PropTypes.func.isRequired,
   summaryQuantity: PropTypes.number,
   summarySubtotal: PropTypes.number,
+  products: PropTypes.array, // eslint-disable-line react/forbid-prop-types,
 };
 
 PaymentPage.defaultProps = {
@@ -171,6 +174,7 @@ PaymentPage.defaultProps = {
   isRedirect: false,
   summaryQuantity: undefined,
   summarySubtotal: undefined,
+  products: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -254,6 +254,7 @@ class Checkout extends React.Component {
               loading={loading}
               isQuantityUpdating={isQuantityUpdating}
               enableStripePaymentProcessor={enableStripePaymentProcessor}
+              products={this.props.products}
             />
           </Elements>
         ) : (loading && (this.renderBillingFormSkeleton()))}
@@ -300,6 +301,7 @@ Checkout.propTypes = {
   orderType: PropTypes.oneOf(Object.values(ORDER_TYPES)),
   enableStripePaymentProcessor: PropTypes.bool,
   clientSecretId: PropTypes.string,
+  products: PropTypes.array, // eslint-disable-line react/forbid-prop-types,
 };
 
 Checkout.defaultProps = {
@@ -312,6 +314,7 @@ Checkout.defaultProps = {
   orderType: ORDER_TYPES.SEAT,
   enableStripePaymentProcessor: false,
   clientSecretId: null,
+  products: [],
 };
 
 const mapStateToProps = (state) => ({

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -38,6 +38,7 @@ function StripePaymentForm({
   onSubmitButtonClick,
   options,
   submitErrors,
+  products,
   issueError: issueErrorDispatcher,
 }) {
   const stripe = useStripe();
@@ -128,7 +129,13 @@ function StripePaymentForm({
       } else {
         // Otherwise send paymentIntent.id to your server
         // TODO: refactor to fetch in service.js
-        const postData = formurlencoded({ payment_intent_id: result.paymentIntent.id });
+
+        // generate comma separated list of product SKUs
+        const skus = products.map(({ sku }) => sku).join(',');
+        const postData = formurlencoded({
+          payment_intent_id: result.paymentIntent.id,
+          skus,
+        });
         await getAuthenticatedHttpClient()
           .post(
             `${process.env.STRIPE_RESPONSE_URL}`,
@@ -241,6 +248,7 @@ StripePaymentForm.propTypes = {
   onSubmitButtonClick: PropTypes.func.isRequired,
   options: PropTypes.object, // eslint-disable-line react/forbid-prop-types,
   submitErrors: PropTypes.objectOf(PropTypes.string),
+  products: PropTypes.array, // eslint-disable-line react/forbid-prop-types,
   issueError: PropTypes.func.isRequired,
 };
 
@@ -252,6 +260,7 @@ StripePaymentForm.defaultProps = {
   isQuantityUpdating: false,
   isProcessing: false,
   submitErrors: {},
+  products: [],
   options: null,
 };
 


### PR DESCRIPTION
The intent of this PR is to hand product SKUs, that were present at load time of the payment page, over to the backend to verify the basket hasn't changed in the background (to prevent a user from checking out with the wrong item).

Initial approach taken was to simply hand the products down the component tree to the place where the actual stripe calls/purchase is being made. This is the first pass to see things work to get buy-in on general design, but another thought was to add the product SKUs to state, so that instead of drilling down through the components, the payment form can snag the SKUs right from there (state).

This still needs tests in any case.

Companion ecommerce PR: https://github.com/openedx/ecommerce/pull/3876


## Anyone merging to this repository is expected to [promptly release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
<!--
Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?

Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.
-->

## Supporting information
<!--
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
-->

## Testing instructions
<!--
Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?
-->

## Other information
<!-- 
Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
-->

## Checklist
- [ ] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [ ] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
