### PR TITLE
fix: add error message for purchasing duplicate baskets. rename skuError

### DIFF
--- a/src/payment/AlertCodeMessages.jsx
+++ b/src/payment/AlertCodeMessages.jsx
@@ -79,10 +79,10 @@ export function TransactionDeclined() {
   );
 }
 
-export function SkuError() {
+export function BasketChangedError() {
   return (
     <FormattedMessage
-      id="payment.messages.transaction.error.sku"
+      id="payment.messages.transaction.error.basket_changed"
       defaultMessage="Your cart has changed since navigating to this page. Please reload the page and verify the product you are purchasing."
       description="Notifies the user their cart has changed, so they can reload the page to see what it actually contains."
     />

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -20,7 +20,7 @@ import {
   SingleEnrollmentCodeWarning,
   EnrollmentCodeQuantityUpdated,
   TransactionDeclined,
-  SkuError,
+  BasketChangedError,
   CaptureKeyTimeoutTwoMinutes,
   CaptureKeyTimeoutOneMinute,
 } from './AlertCodeMessages';
@@ -140,8 +140,8 @@ class PaymentPage extends React.Component {
             'transaction-declined-message': (
               <TransactionDeclined />
             ),
-            'sku-error-message': (
-              <SkuError />
+            'basket-changed-error-message': (
+              <BasketChangedError />
             ),
             'capture-key-2mins-message': (
               <CaptureKeyTimeoutTwoMinutes />

--- a/src/payment/data/actions.js
+++ b/src/payment/data/actions.js
@@ -20,7 +20,7 @@ export const addCoupon = createRoutine('ADD_COUPON');
 export const removeCoupon = createRoutine('REMOVE_COUPON');
 export const updateQuantity = createRoutine('UPDATE_QUANTITY');
 export const issueError = createRoutine('ISSUE_ERROR');
-export const skuError = createRoutine('SKU_ERROR');
+export const basketChangedError = createRoutine('BASKET_CHANGED_ERROR');
 
 // Actions and their action creators
 export const BASKET_DATA_RECEIVED = 'BASKET_DATA_RECEIVED';
@@ -79,4 +79,4 @@ export const clientSecretDataReceived = clientSecret => ({
 
 export const ISSUE_ERROR = 'ISSUE_ERROR';
 
-export const SKU_ERROR = 'SKU_ERROR';
+export const BASKET_CHANGED_ERROR = 'BASKET_CHANGED_ERROR';

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -24,7 +24,7 @@ import {
   clientSecretProcessing,
   fetchClientSecret,
   issueError,
-  skuError,
+  basketChangedError,
 } from './actions';
 
 import { STATUS_LOADING } from '../checkout/payment-form/flex-microform/constants';
@@ -283,11 +283,11 @@ export function* handleIssueError() {
   }, true);
 }
 
-export function* handleSkuError() {
+export function* handleBasketChangedError() {
   yield call(handleErrors, {
     messages: [
       {
-        code: 'sku-error-message',
+        code: 'basket-changed-error-message',
         messageType: 'error',
       },
     ],
@@ -304,5 +304,5 @@ export default function* saga() {
   yield takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity);
   yield takeEvery(submitPayment.TRIGGER, handleSubmitPayment);
   yield takeEvery(issueError.TRIGGER, handleIssueError);
-  yield takeEvery(skuError.TRIGGER, handleSkuError);
+  yield takeEvery(basketChangedError.TRIGGER, handleBasketChangedError);
 }

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -16,7 +16,7 @@ import paymentSaga, {
   handleCaptureKeyTimeout,
   handleFetchClientSecret,
   handleIssueError,
-  handleSkuError,
+  handleBasketChangedError,
 } from './sagas';
 import { transformResults } from './service';
 import {
@@ -31,7 +31,7 @@ import {
   CAPTURE_KEY_START_TIMEOUT,
   fetchClientSecret,
   issueError,
-  skuError,
+  basketChangedError,
 } from './actions';
 import { clearMessages, MESSAGE_TYPES, addMessage } from '../../feedback';
 
@@ -750,7 +750,7 @@ describe('saga tests', () => {
     expect(gen.next().value).toEqual(takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity));
     expect(gen.next().value).toEqual(takeEvery(submitPayment.TRIGGER, handleSubmitPayment));
     expect(gen.next().value).toEqual(takeEvery(issueError.TRIGGER, handleIssueError));
-    expect(gen.next().value).toEqual(takeEvery(skuError.TRIGGER, handleSkuError));
+    expect(gen.next().value).toEqual(takeEvery(basketChangedError.TRIGGER, handleBasketChangedError));
 
     // If you find yourself adding something here, there are probably more tests to write!
 


### PR DESCRIPTION
If you have a 2 tabs open with the same basket, you place the order on 1 tab, then go to the _other_ tab and attempt to purchase, you will get a message in the stripe element saying "An unexpected error occurred" because the paymentIntent has already succeeded after placing the first order. The problem is that this message is not useful for the user.

Now, an error message will display instructing the user to reload their page, and once they reload, they will reach the empty basket page, which is the correct behavior given that they already purchased the basket.


<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone merging to this repository is expected to [promptly release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
<!--
Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?

Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.
-->

## Supporting information
<!--
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
-->

## Testing instructions
<!--
Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?
-->

## Other information
<!-- 
Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
-->

## Checklist
- [ ] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [ ] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
