### PR TITLE
feat: tell user their basket has changed when they try to purchase a …

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -5,7 +5,8 @@
         "GHSA-f8q6-p94x-37v3",
         "GHSA-76p3-8jx3-jpfq",
         "GHSA-3rfm-jhwj-7488",
-        "GHSA-hhq3-ff78-jv3g"
+        "GHSA-hhq3-ff78-jv3g",
+        "GHSA-9c47-m6qq-7p4h"
     ],
     "moderate": true
 }

--- a/src/feedback/data/sagas.js
+++ b/src/feedback/data/sagas.js
@@ -15,7 +15,7 @@ export function* handleErrors(e, clearExistingMessages) {
   if (e.errors !== undefined) {
     for (let i = 0; i < e.errors.length; i++) { // eslint-disable-line no-plusplus
       const error = e.errors[i];
-      if (error.code === 'sku-error-message') {
+      if (error.code === 'basket-changed-error-message') {
         yield put(addMessage(error.code, error.userMessage, {}, MESSAGE_TYPES.ERROR));
       } else if (error.data === undefined && error.messageType === null) {
         yield put(addMessage('transaction-declined-message', error.userMessage, {}, MESSAGE_TYPES.ERROR));

--- a/src/payment/AlertCodeMessages.jsx
+++ b/src/payment/AlertCodeMessages.jsx
@@ -79,10 +79,10 @@ export function TransactionDeclined() {
   );
 }
 
-export function SkuError() {
+export function BasketChangedError() {
   return (
     <FormattedMessage
-      id="payment.messages.transaction.error.sku"
+      id="payment.messages.transaction.error.basket_changed"
       defaultMessage="Your cart has changed since navigating to this page. Please reload the page and verify the product you are purchasing."
       description="Notifies the user their cart has changed, so they can reload the page to see what it actually contains."
     />

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -20,7 +20,7 @@ import {
   SingleEnrollmentCodeWarning,
   EnrollmentCodeQuantityUpdated,
   TransactionDeclined,
-  SkuError,
+  BasketChangedError,
   CaptureKeyTimeoutTwoMinutes,
   CaptureKeyTimeoutOneMinute,
 } from './AlertCodeMessages';
@@ -140,8 +140,8 @@ class PaymentPage extends React.Component {
             'transaction-declined-message': (
               <TransactionDeclined />
             ),
-            'sku-error-message': (
-              <SkuError />
+            'basket-changed-error-message': (
+              <BasketChangedError />
             ),
             'capture-key-2mins-message': (
               <CaptureKeyTimeoutTwoMinutes />

--- a/src/payment/data/handleRequestError.js
+++ b/src/payment/data/handleRequestError.js
@@ -73,12 +73,23 @@ export default function handleRequestError(error) {
     ]);
   }
 
-  // SKU error
+  // SKU mismatch error
   if (error.response && error.response.data.sku_error) {
     logInfo('SKU Error', error.response.data.sku_error);
     handleApiErrors([
       {
-        error_code: 'sku-error-message',
+        error_code: 'basket-changed-error-message',
+        user_message: 'error',
+      },
+    ]);
+  }
+
+  // Basket already purchased
+  if (error.code === 'payment_intent_unexpected_state' && error.type === 'invalid_request_error') {
+    logInfo('Basket Changed Error', error.code);
+    handleApiErrors([
+      {
+        error_code: 'basket-changed-error-message',
         user_message: 'error',
       },
     ]);


### PR DESCRIPTION
…basket that is now closed

This PR does the following:
1. Moves updatePaymentIntent call to the service.js file, so there is access to the sagas (so we can dispatch the event to get the red banner with the error message displayed)
2. Removes the block of code with the error text that appears just below the Stripe elements
3. Renames SkuError to BasketChangedError, because in the SkuError case and this case, we want the same thing to happen: ask the user to refresh to see what their basket really contains (even if that's nothing)


<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone merging to this repository is expected to [promptly release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Description
<!--
Describe what this pull request changes, and why these changes were made. How will these changes affect other people, installations of edx, etc.?

Please include links to any relevant ADRs, design artifacts, and decision documents. Make sure to document the rationale behind significant changes in the repo, per [OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author", "Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these changes.
-->

## Supporting information
<!--
Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.
-->

## Testing instructions
<!--
Please provide detailed step-by-step instructions for testing this change; how did YOU test this change?
-->

## Other information
<!-- 
Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, OpenEdx vs. edx.org differences, development vs. production environment differences, security, or accessibility.
-->

## Checklist
- [ ] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [ ] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
