### PR TITLE
feat: Add stripe 3DS to checkout page(WIP)

### DIFF
--- a/src/payment/payment-methods/stripe/service.js
+++ b/src/payment/payment-methods/stripe/service.js
@@ -75,34 +75,70 @@ export default async function checkout(
       {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       },
-    )
-    .then(response => {
-      setLocation(response.data.receipt_page_url);
-    })
-    .catch(error => {
+  )
+  .then(response => {
+    console.log(response);
+    handleServerResponse(response, stripe, setLocation, postData);
+  })
+  .catch(error => {
       const errorData = error.response ? error.response.data : null;
-      if (errorData && error.response.data.sdn_check_failure) {
-        /* istanbul ignore next */
-        if (getConfig().ENVIRONMENT !== 'test') {
-          // SDN failure: redirect to Ecommerce SDN error page.
-          setLocation(`${getConfig().ECOMMERCE_BASE_URL}/payment/sdn/failure/`);
+        if (errorData && error.response.data.sdn_check_failure) {
+          /* istanbul ignore next */
+          if (getConfig().ENVIRONMENT !== 'test') {
+            // SDN failure: redirect to Ecommerce SDN error page.
+            setLocation(`${getConfig().ECOMMERCE_BASE_URL}/payment/sdn/failure/`);
+          }
+          logError(error, {
+            messagePrefix: 'SDN Check Error',
+            paymentMethod: 'Stripe',
+            paymentErrorType: 'SDN Check Submit Api',
+            basketId,
+          });
+          throw new Error('This card holder did not pass the SDN check.');
+        } else {
+          // Log error and tell user.
+          logError(error, {
+            messagePrefix: 'Stripe Submit Error',
+            paymentMethod: 'Stripe',
+            paymentErrorType: 'Submit Error',
+            basketId,
+          });
+          handleApiError(error);
         }
-        logError(error, {
-          messagePrefix: 'SDN Check Error',
-          paymentMethod: 'Stripe',
-          paymentErrorType: 'SDN Check Submit Api',
-          basketId,
-        });
-        throw new Error('This card holder did not pass the SDN check.');
-      } else {
-        // Log error and tell user.
-        logError(error, {
-          messagePrefix: 'Stripe Submit Error',
-          paymentMethod: 'Stripe',
-          paymentErrorType: 'Submit Error',
-          basketId,
-        });
-        handleApiError(error);
-      }
-    });
+  });      
+}
+
+const handleServerResponse = async (response, stripe, setLocation, postData) => {
+  
+  if (response.requires_action) {
+    console.log('b');
+    const { error: errorAction, paymentIntent } = await stripe.handleNextAction({clientSecret: response.payment_intent_client_secret});
+    console.log('c');
+    console.log(paymentIntent);
+    if (errorAction) {
+      console.log(errorAction);
+
+    }
+    else {
+      console.log('Actions handled success');
+      await getAuthenticatedHttpClient()
+        .post(
+          `${process.env.STRIPE_RESPONSE_URL}`,
+          postData,
+          {
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          },
+      )
+      .then(response => {
+        console.log(response);
+        handleServerResponse(response, stripe, setLocation);
+      })
+
+    }
+    
+  }
+  else{
+    //simple payment successful
+    setLocation(response.data.receipt_page_url);
+  }
 }


### PR DESCRIPTION
[REV-3241](https://2u-internal.atlassian.net/browse/REV-3241)
This PR updates the checkout flow to respond to an 'action required' response from ecommerce.  It will redirect the user to perform an external authentication and then return to the url specified in [ecommerce/extensions/payment/processors/stripe.py](https://github.com/openedx/ecommerce/blob/d24cb96a0c06fed20db053c1de68b4d2a3188c6c/ecommerce/extensions/payment/processors/stripe.py#L176)

Note:
- This will NOT be merged/deployed before the updates to ecommerce for implementing webhooks are made and the work in  [REV-3187](https://2u-internal.atlassian.net/browse/REV-3187) is complete
- This was developed using branch: [julianajlk/REV-3240/three-d-secure](https://github.com/openedx/ecommerce/tree/julianajlk/REV-3240/three-d-secure)
- Currently the payment will complete on Stripe end but is not updated in ecommerce
- tested with cards from [stripe docs](https://stripe.com/docs/payments/3d-secure)

Screenshot of 3DS page:
<img width="756" alt="Screenshot 2023-02-21 at 2 12 10 PM" src="https://user-images.githubusercontent.com/43426024/220437355-72da8e76-f9df-434c-827c-c7c99c5ec713.png">
