### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export TRANSIFEX_RESOURCE = frontend-app-payment
 transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fr_CA,it_IT,pt_PT,de_DE"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -42,9 +43,24 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f -t --mode reviewed --languages=$(transifex_langs)
+	tx pull -f --mode reviewed --languages=$(transifex_langs)
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+      && atlas pull --filter=$(transifex_langs) \
+               translations/frontend-component-header/src/i18n/messages:frontend-component-header  \
+               translations/frontend-component-footer/src/i18n/messages:frontend-component-footer \
+               translations/paragon/src/i18n/messages:paragon \
+               translations/frontend-app-payment/src/i18n/messages:frontend-app-payment
+
+	$(intl_imports) frontend-component-header frontend-component-footer paragon frontend-app-payment
+endif
 
 # This target is used by CI.
 validate-no-uncommitted-package-lock-changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-component-footer": "^12.0.0",
         "@edx/frontend-component-header": "^4.0.0",
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.2.0",
         "@edx/paragon": "^20.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/free-brands-svg-icons": "^6.1.1",
@@ -2209,9 +2209,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.0.1.tgz",
-      "integrity": "sha512-79uo/iQJ7P1tIY0MHTQ874W/NrNkcDe4BFC/0AvKF4DNrkqq9AkUFKqQ3hvd8E9C1EK189KlcAmo6FFQ67IFXg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.3.0.tgz",
+      "integrity": "sha512-8ySsSN8c8GHLDqhVwXE1yKm9717KaZ9AyTTnD8TQlBL81CQ0CaR/QCNaNmm3imYnGVkyU+XeReLILybyWiLSeQ==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -2234,13 +2234,14 @@
         "universal-cookie": "4.0.4"
       },
       "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
         "@edx/paragon": ">= 10.0.0 < 21.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
         "react-redux": "^7.1.1",
         "react-router-dom": "^5.0.1",
         "redux": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "^12.0.0",
     "@edx/frontend-component-header": "^4.0.0",
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-platform": "^4.2.0",
     "@edx/paragon": "^20.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,3 +1,7 @@
+import { messages as paragonMessages } from '@edx/paragon';
+import { messages as headerMessages } from '@edx/frontend-component-header';
+import { messages as footerMessages } from '@edx/frontend-component-footer';
+
 import arMessages from './messages/ar.json';
 import frMessages from './messages/fr.json';
 import es419Messages from './messages/es_419.json';
@@ -15,7 +19,7 @@ import itITMessages from './messages/it_IT.json';
 import ptPTMessages from './messages/pt_PT.json';
 // no need to import en messages-- they are in the defaultMessage field
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   // override the protected translations
   'es-419': { ...es419Messages, ...es419MessagesProtected },
@@ -33,4 +37,9 @@ const messages = {
   'pt-pt': ptPTMessages,
 };
 
-export default messages;
+export default [
+  headerMessages,
+  footerMessages,
+  paragonMessages,
+  appMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,19 +14,19 @@ import {
 } from '@edx/frontend-platform';
 import { ErrorPage, AppProvider } from '@edx/frontend-platform/react';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { messages as paragonMessages } from '@edx/paragon';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Switch } from 'react-router-dom';
 
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getLoggingService, logError } from '@edx/frontend-platform/logging';
-import Header, { messages as headerMessages } from '@edx/frontend-component-header';
-import Footer, { messages as footerMessages } from '@edx/frontend-component-footer';
+import Header from '@edx/frontend-component-header';
+import Footer from '@edx/frontend-component-footer';
 
 import { configure as configureI18n } from '@edx/frontend-platform/i18n/lib';
 import { getLocale } from '@edx/frontend-platform/i18n';
-import appMessages from './i18n';
+import messages from './i18n';
+
 import {
   PaymentPage,
   EcommerceRedirect,
@@ -151,12 +151,7 @@ subscribe(APP_AUTH_INITIALIZED, () => {
 });
 
 initialize({
-  messages: [
-    appMessages,
-    headerMessages,
-    footerMessages,
-    paragonMessages,
-  ],
+  messages,
   requireAuthenticatedUser: true,
   hydrateAuthenticatedUser: true,
 });


### PR DESCRIPTION
Changes
-------
 - Bump frontend-platform to bring intl-imports.js script
 - Move all i18n imports into `src/i18n/index.js` so intl-imports.js can override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.
 - Fixed lint rules for frontend-platform@4.1.0

Refs: [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) implementing Translation Infrastructure OEP-58.


## Checklist
- [x] Consider PCI compliance impact and whether this PR changes how credit card information is handled: **No impact on credit card handling**
- [ ] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
 - [x] Fix tests and lint rules
 - [x] Test pulled translations
 - [x] Quick QA for translated content: <details><summary>Screenshot</summary><kbd>
![image](https://user-images.githubusercontent.com/645156/233950075-059ce7c1-aee4-4475-ae36-23d7487b543c.png)
</kbd></details> 
      



References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/


