### PR TITLE
feat: Add programTitle to POST request data to Subscriptions

### DIFF
--- a/src/subscription/subscription-methods/stripe/service.js
+++ b/src/subscription/subscription-methods/stripe/service.js
@@ -9,7 +9,7 @@ import { logError } from '@edx/frontend-platform/logging';
  * 3. Show confirmation modal for subscription customer
  */
 export async function subscriptionStripeCheckout(
-  { programUuid },
+  { programUuid, programTitle },
   {
     elements, stripe, context, values,
   },
@@ -49,6 +49,7 @@ export async function subscriptionStripeCheckout(
     }
     const postData = {
       program_uuid: programUuid,
+      program_title: programTitle,
       payment_method_id: paymentMethod.id,
       billing_details: { ...paymentMethod.billing_details, firstname: firstName, lastname: lastName },
     };


### PR DESCRIPTION
[PON-168](https://2u-internal.atlassian.net/browse/PON-168).

In order to show the Program Title in the Customer Portal in Stripe, we need to add it to the subscription created server-side on POST to the `/stripe-checkout` endpoint. Passing this along as request data.

Accompanying PR: https://github.com/edx/subscriptions/pull/78