### PR TITLE
feat: THES-105: Payment State Polling

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -9,7 +9,9 @@
         "GHSA-pfrx-2q88-qq97",
         "GHSA-rc47-6667-2j5j",
         "GHSA-hc6q-2mpp-qw7j",
-        "GHSA-f9xv-q969-pqx4"
+        "GHSA-f9xv-q969-pqx4",
+        "GHSA-c2qf-rxjj-qqgw",
+        "GHSA-j8xg-fqg3-53r7"
     ],
     "moderate": true
 }

--- a/src/payment/PaymentPage.jsx
+++ b/src/payment/PaymentPage.jsx
@@ -19,6 +19,7 @@ import EmptyCartMessage from './EmptyCartMessage';
 import Cart from './cart/Cart';
 import Checkout from './checkout/Checkout';
 import { FormattedAlertList } from '../components/formatted-alert-list/FormattedAlertList';
+import { PaymentProcessingModal } from './PaymentProcessingModal';
 
 class PaymentPage extends React.Component {
   constructor(props) {
@@ -96,6 +97,7 @@ class PaymentPage extends React.Component {
           />
         </h1>
         <div className="col-md-5 pr-md-5 col-basket-summary">
+          <PaymentProcessingModal />
           <Cart
             isNumEnrolledExperiment={isNumEnrolledExperiment}
             REV1045Experiment={REV1045Experiment}

--- a/src/payment/PaymentProcessingModal.jsx
+++ b/src/payment/PaymentProcessingModal.jsx
@@ -17,10 +17,10 @@ import { POLLING_PAYMENT_STATES } from './data/constants';
  * @see paymentProcessStatusSelector
  * @see paymentProcessStatusIsPollingSelector
  *
- * Primary Event: `updatePaymentState`
- * @see updatePaymentState
+ * Primary Event: `pollPaymentState`
+ * @see pollPaymentState
  *
- * If you wish to perform an action as this dialog closes, please register for the updatePaymentState fulfill event.
+ * If you wish to perform an action as this dialog closes, please register for the pollPaymentState fulfill event.
  */
 export const PaymentProcessingModal = () => {
   /**
@@ -49,7 +49,7 @@ export const PaymentProcessingModal = () => {
     <ModalDialog
       title="Your Payment is Processing"
       isOpen={isOpen}
-      onClose={() => { /* Noop, @see updatePaymentState fulfill */ }}
+      onClose={() => { /* Noop, @see pollPaymentState fulfill */ }}
       hasCloseButton={false}
       isFullscreenOnMobile={false}
     >

--- a/src/payment/PaymentProcessingModal.jsx
+++ b/src/payment/PaymentProcessingModal.jsx
@@ -1,34 +1,55 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  ModalDialog, Spinner,
-} from '@edx/paragon';
-import { useSelector } from 'react-redux';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { ModalDialog, Spinner } from '@edx/paragon';
+import { connect, useSelector } from 'react-redux';
+import { injectIntl, useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './PaymentProcessingModal.messages';
-import { paymentProcessStatusSelector } from './data/selectors';
+import { paymentProcessStatusIsPollingSelector, paymentProcessStatusSelector } from './data/selectors';
+import { POLLING_PAYMENT_STATES } from './data/constants';
 
 /**
  * PaymentProcessingModal
+ *
+ * This modal is controlled primarily by some Redux selectors.
+ *
+ * Controls Visibility: `paymentProcessStatusSelector`, `paymentProcessStatusIsPollingSelector`
+ * @see paymentProcessStatusSelector
+ * @see paymentProcessStatusIsPollingSelector
+ *
+ * Primary Event: `updatePaymentState`
+ * @see updatePaymentState
+ *
+ * If you wish to perform an action as this dialog closes, please register for the updatePaymentState fulfill event.
  */
 export const PaymentProcessingModal = () => {
+  /**
+   * Determine if the Dialog should be open based on Redux state input
+   * @param s {PAYMENT_STATE} The value of the payment state as we currently know it (`paymentProcessStatusSelector`)
+   * @param p {boolean} is currently polling/still polling for status (`paymentProcessStatusIsPollingSelector`)
+   * @return {boolean}
+   */
+  const shouldBeOpen = (s, p) => p || POLLING_PAYMENT_STATES.includes(s);
+
   const intl = useIntl();
-  const shouldBeOpen = (status) => status === 'pending';
+
   const status = useSelector(paymentProcessStatusSelector);
-  const [isOpen, setOpen] = useState(shouldBeOpen(status));
+  const isPolling = useSelector(paymentProcessStatusIsPollingSelector);
+  const [isOpen, setOpen] = useState(shouldBeOpen(status, isPolling));
 
   useEffect(() => {
-    setOpen(shouldBeOpen(status));
-  }, [status]);
+    setOpen(shouldBeOpen(status, isPolling));
+  }, [status, isPolling]);
 
-  if (!isOpen) { return null; }
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <ModalDialog
       title="Your Payment is Processing"
       isOpen={isOpen}
-      onClose={() => {}}
+      onClose={() => { /* Noop, @see updatePaymentState fulfill */ }}
       hasCloseButton={false}
       isFullscreenOnMobile={false}
     >
@@ -51,4 +72,4 @@ export const PaymentProcessingModal = () => {
   );
 };
 
-export default PaymentProcessingModal;
+export default connect()(injectIntl(PaymentProcessingModal));

--- a/src/payment/PaymentProcessingModal.test.jsx
+++ b/src/payment/PaymentProcessingModal.test.jsx
@@ -39,7 +39,7 @@ const basketStoreGenerator = (paymentState = PAYMENT_STATE.DEFAULT, keepPolling 
   }
 );
 
-const shouldPoll = (payState) => payState === PAYMENT_STATE.PENDING || payState === PAYMENT_STATE.PROCESSING;
+const shouldPoll = (payState) => payState === PAYMENT_STATE.PENDING;
 
 const buildDescription = (tp) => `is ${shouldPoll(tp.status) ? '' : 'NOT '}shown (status == '${tp.status}')`;
 
@@ -80,7 +80,6 @@ describe('<PaymentProcessingModal />', () => {
 
   /* eslint-disable no-multi-spaces */
   const tests = [
-    { expect: true,  status: PAYMENT_STATE.PROCESSING },
     { expect: true,  status: PAYMENT_STATE.PENDING    },
     { expect: false, status: PAYMENT_STATE.FAILED     },
     { expect: false, status: PAYMENT_STATE.DEFAULT    },

--- a/src/payment/PaymentProcessingModal.test.jsx
+++ b/src/payment/PaymentProcessingModal.test.jsx
@@ -9,8 +9,9 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
 import React from 'react';
 import { PaymentProcessingModal } from './PaymentProcessingModal';
+import { PAYMENT_STATE } from './data/constants';
 
-const basketStoreGenerator = (isProcessing) => (
+const basketStoreGenerator = (paymentState = PAYMENT_STATE.DEFAULT, keepPolling = false) => (
   {
     payment: {
       basket: {
@@ -18,9 +19,18 @@ const basketStoreGenerator = (isProcessing) => (
         loaded: false,
         submitting: false,
         redirect: false,
-        isBasketProcessing: isProcessing,
+        isBasketProcessing: false,
         products: [{ sku: '00000' }],
         enableStripePaymentProcessor: true,
+        /** Modified by both getActiveOrder and paymentStatePolling */
+        // eslint-disable-next-line object-shorthand
+        paymentState: paymentState,
+        /** state specific to paymentStatePolling */
+        paymentStatePolling: {
+          // eslint-disable-next-line object-shorthand
+          keepPolling: keepPolling, // TODO: GRM: FIX both debugging items (this is one)
+          counter: 5, // debugging
+        },
       },
       clientSecret: { isClientSecretProcessing: false, clientSecretId: '' },
     },
@@ -29,9 +39,9 @@ const basketStoreGenerator = (isProcessing) => (
   }
 );
 
-const statusStringToBool = (str) => str === 'pending';
+const shouldPoll = (payState) => payState === PAYMENT_STATE.PENDING || payState === PAYMENT_STATE.PROCESSING;
 
-const buildDescription = (tp) => `is ${statusStringToBool(tp.status) ? '' : 'NOT '}shown (status == '${tp.status}')`;
+const buildDescription = (tp) => `is ${shouldPoll(tp.status) ? '' : 'NOT '}shown (status == '${tp.status}')`;
 
 /**
  * PaymentProcessingModal Test
@@ -68,18 +78,22 @@ describe('<PaymentProcessingModal />', () => {
     },
   });
 
+  /* eslint-disable no-multi-spaces */
   const tests = [
-    { expect: true, status: 'pending' },
-    { expect: false, status: 'failed' },
-    { expect: false, status: 'draft' },
-    { expect: false, status: 'checkout' },
+    { expect: true,  status: PAYMENT_STATE.PROCESSING },
+    { expect: true,  status: PAYMENT_STATE.PENDING    },
+    { expect: false, status: PAYMENT_STATE.FAILED     },
+    { expect: false, status: PAYMENT_STATE.DEFAULT    },
+    { expect: false, status: PAYMENT_STATE.CHECKOUT   },
+    { expect: false, status: PAYMENT_STATE.COMPLETED  },
   ];
+  /* eslint-enable no-multi-spaces */
 
   for (let i = 0, testPlan = tests[i]; i < tests.length; i++, testPlan = tests[i]) {
     describe(buildDescription(testPlan), () => {
-      it(`${statusStringToBool(testPlan.status) ? 'renders a dialog' : 'does not render a dialog'}`, () => {
+      it(`${shouldPoll(testPlan.status) ? 'renders a dialog' : 'does not render a dialog'}`, () => {
         const mockStore = configureMockStore();
-        const store = mockStore(basketStoreGenerator(statusStringToBool(testPlan.status)));
+        const store = mockStore(basketStoreGenerator(testPlan.status, shouldPoll(testPlan.status)));
 
         const wrapper = mount((
           <IntlProvider locale="en">

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -16,7 +16,6 @@ import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
-import { PaymentProcessingModal } from '../../PaymentProcessingModal';
 import SubscriptionSubmitButton from '../../../subscription/checkout/submit-button/SubscriptionSubmitButton';
 import MonthlyBillingNotification from '../../../subscription/checkout/monthly-billing-notification/MonthlyBillingNotification';
 
@@ -186,18 +185,13 @@ const StripePaymentForm = ({
           />
         </>
       ) : (
-      // Standard Purchase Flow
-        <>
-          {isProcessing && (
-            <PaymentProcessingModal />
-          ) }
-          <PlaceOrderButton
-            onSubmitButtonClick={onSubmitButtonClick}
-            showLoadingButton={showLoadingButton}
-            disabled={submitting}
-            isProcessing={isProcessing}
-          />
-        </>
+        // Standard Purchase Flow
+        <PlaceOrderButton
+          onSubmitButtonClick={onSubmitButtonClick}
+          showLoadingButton={showLoadingButton}
+          disabled={submitting}
+          isProcessing={isProcessing}
+        />
       )}
 
     </form>

--- a/src/payment/data/__snapshots__/redux.test.js.snap
+++ b/src/payment/data/__snapshots__/redux.test.js.snap
@@ -6,6 +6,10 @@ Object {
     "isBasketProcessing": false,
     "loaded": false,
     "loading": true,
+    "paymentState": "checkout",
+    "paymentStatePolling": Object {
+      "keepPolling": false,
+    },
     "products": Array [],
     "redirect": false,
     "submitting": false,
@@ -28,6 +32,10 @@ Object {
     "isBasketProcessing": false,
     "loaded": false,
     "loading": true,
+    "paymentState": "checkout",
+    "paymentStatePolling": Object {
+      "keepPolling": false,
+    },
     "products": Array [],
     "redirect": false,
     "submitting": false,
@@ -50,6 +58,10 @@ Object {
     "isBasketProcessing": false,
     "loaded": false,
     "loading": true,
+    "paymentState": "checkout",
+    "paymentStatePolling": Object {
+      "keepPolling": false,
+    },
     "products": Array [],
     "redirect": false,
     "submitting": false,

--- a/src/payment/data/actions.js
+++ b/src/payment/data/actions.js
@@ -20,6 +20,7 @@ export const fetchActiveOrder = createRoutine('FETCH_ACTIVE_ORDER');
 export const addCoupon = createRoutine('ADD_COUPON');
 export const removeCoupon = createRoutine('REMOVE_COUPON');
 export const updateQuantity = createRoutine('UPDATE_QUANTITY');
+export const updatePaymentState = createRoutine('UPDATE_PAYMENT_STATE');
 
 // Actions and their action creators
 export const BASKET_DATA_RECEIVED = 'BASKET_DATA_RECEIVED';
@@ -74,4 +75,11 @@ export const CLIENT_SECRET_DATA_RECEIVED = 'CLIENT_SECRET_DATA_RECEIVED';
 export const clientSecretDataReceived = clientSecret => ({
   type: CLIENT_SECRET_DATA_RECEIVED,
   payload: clientSecret,
+});
+
+export const PAYMENT_STATE_DATA_RECEIVED = 'PAYMENT_STATE_DATA_RECEIVED';
+
+export const paymentStateDataReceived = paymentState => ({
+  type: PAYMENT_STATE_DATA_RECEIVED,
+  payload: paymentState,
 });

--- a/src/payment/data/actions.js
+++ b/src/payment/data/actions.js
@@ -20,7 +20,7 @@ export const fetchActiveOrder = createRoutine('FETCH_ACTIVE_ORDER');
 export const addCoupon = createRoutine('ADD_COUPON');
 export const removeCoupon = createRoutine('REMOVE_COUPON');
 export const updateQuantity = createRoutine('UPDATE_QUANTITY');
-export const updatePaymentState = createRoutine('UPDATE_PAYMENT_STATE');
+export const pollPaymentState = createRoutine('UPDATE_PAYMENT_STATE');
 
 // Actions and their action creators
 export const BASKET_DATA_RECEIVED = 'BASKET_DATA_RECEIVED';

--- a/src/payment/data/constants.js
+++ b/src/payment/data/constants.js
@@ -34,10 +34,6 @@ export const PAYMENT_STATE = (((webserviceEnum = {
    * Payment is Pending
    */
   PENDING: 'pending',
-  /**
-   * Async Processing of payment is ongoing.
-   */
-  PROCESSING: 'processing',
 }) => ({
   ...webserviceEnum,
 
@@ -64,6 +60,6 @@ export const PAYMENT_STATE = (((webserviceEnum = {
  * @see PAYMENT_STATE
  */
 export const POLLING_PAYMENT_STATES = [
-  PAYMENT_STATE.PROCESSING,
+  PAYMENT_STATE.PENDING,
   PAYMENT_STATE.HTTP_ERROR,
 ];

--- a/src/payment/data/constants.js
+++ b/src/payment/data/constants.js
@@ -8,3 +8,62 @@ export const CERTIFICATE_TYPES = {
   VERIFIED: 'verified',
   CREDIT: 'credit',
 };
+
+/**
+ * Payment State for async payment processing and UI Dialog Control.
+ *
+ * @see POLLING_PAYMENT_STATES
+ *
+ * @note: This enum is unique to Commerce Coordinator backend.
+ */
+export const PAYMENT_STATE = (((webserviceEnum = {
+  // The enum as the WS Sees it.
+  /**
+   * Draft (Checkout) Payment
+   */
+  CHECKOUT: 'checkout',
+  /**
+   * Payment Complete
+   */
+  COMPLETED: 'completed',
+  /**
+   * Server Side Payment Failure
+   */
+  FAILED: 'failed',
+  /**
+   * Payment is Pending
+   */
+  PENDING: 'pending',
+  /**
+   * Async Processing of payment is ongoing.
+   */
+  PROCESSING: 'processing',
+}) => ({
+  ...webserviceEnum,
+
+  // Our Additions
+
+  /**
+   * Default according to Redux initial state. (Should be an alias of an official value)
+   *
+   * @see PAYMENT_STATE.CHECKOUT
+   */
+  DEFAULT: webserviceEnum.CHECKOUT,
+
+  /**
+   * An HTTP Error has occurred between the client and server, this should not be sent over the line.
+   *
+   * @note **this is custom to the MFE**, thus a Symbol (which JSON usually skips in serialization)
+   */
+  HTTP_ERROR: Symbol('mfe-only_http_error'),
+}))());
+
+/**
+ * An array of payment states that we intend to run polling against
+ * @type {(string|Symbol)[]} Values from PAYMENT_STATE
+ * @see PAYMENT_STATE
+ */
+export const POLLING_PAYMENT_STATES = [
+  PAYMENT_STATE.PROCESSING,
+  PAYMENT_STATE.HTTP_ERROR,
+];

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -8,15 +8,35 @@ import {
   CLIENT_SECRET_DATA_RECEIVED,
   CLIENT_SECRET_PROCESSING,
   MICROFORM_STATUS,
+  PAYMENT_STATE_DATA_RECEIVED,
   fetchBasket,
   submitPayment,
   fetchCaptureKey,
   fetchClientSecret,
   fetchActiveOrder,
+  updatePaymentState,
 } from './actions';
 
 import { DEFAULT_STATUS } from '../checkout/payment-form/flex-microform/constants';
+import { PAYMENT_STATE, POLLING_PAYMENT_STATES } from './constants';
+import { chainReducers } from './utils';
 
+/**
+ * Internal State for the Payment State Polling Mechanism. Used entirely for Project Theseus.
+ */
+const paymentStatePollingInitialState = {
+  /**
+   * @see paymentProcessStatusIsPollingSelector
+   */
+  keepPolling: false,
+};
+
+/**
+ * Initial basket state
+ *
+ * Certain of these values are reused for Theseus, information o how they are remapped can be found in the
+ *   System Manual.
+ */
 const basketInitialState = {
   loading: true,
   loaded: false,
@@ -24,6 +44,10 @@ const basketInitialState = {
   redirect: false,
   isBasketProcessing: false,
   products: [],
+  /** Modified by both getActiveOrder and paymentStatePolling */
+  paymentState: PAYMENT_STATE.DEFAULT,
+  /** state specific to paymentStatePolling */
+  paymentStatePolling: paymentStatePollingInitialState,
 };
 
 const basket = (state = basketInitialState, action = null) => {
@@ -122,8 +146,51 @@ const clientSecret = (state = clientSecretInitialState, action = null) => {
   return state;
 };
 
+const paymentState = (state = basketInitialState, action = null) => {
+  const shouldPoll = (payState) => POLLING_PAYMENT_STATES.includes(payState);
+
+  if (action !== null && action !== undefined) {
+    switch (action.type) {
+      case updatePaymentState.TRIGGER:
+        return {
+          ...state,
+          paymentStatePolling: {
+            ...state.paymentStatePolling,
+            keepPolling: shouldPoll(state.paymentState),
+          },
+        };
+
+      case updatePaymentState.FULFILL:
+        return {
+          ...state,
+          paymentStatePolling: {
+            ...state.paymentStatePolling,
+            keepPolling: false,
+          },
+        };
+
+      case PAYMENT_STATE_DATA_RECEIVED:
+        return {
+          ...state,
+          paymentState: action.payload.state,
+          paymentStatePolling: {
+            ...state.paymentStatePolling,
+            keepPolling: shouldPoll(action.payload.state),
+            // ...action.payload, // debugging
+          },
+        };
+
+      default:
+    }
+  }
+  return state;
+};
+
 const reducer = combineReducers({
-  basket,
+  basket: chainReducers([
+    basket,
+    paymentState,
+  ]),
   captureKey,
   clientSecret,
 });

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -14,7 +14,7 @@ import {
   fetchCaptureKey,
   fetchClientSecret,
   fetchActiveOrder,
-  updatePaymentState,
+  pollPaymentState,
 } from './actions';
 
 import { DEFAULT_STATUS } from '../checkout/payment-form/flex-microform/constants';
@@ -151,7 +151,7 @@ const paymentState = (state = basketInitialState, action = null) => {
 
   if (action !== null && action !== undefined) {
     switch (action.type) {
-      case updatePaymentState.TRIGGER:
+      case pollPaymentState.TRIGGER:
         return {
           ...state,
           paymentStatePolling: {
@@ -160,7 +160,7 @@ const paymentState = (state = basketInitialState, action = null) => {
           },
         };
 
-      case updatePaymentState.FULFILL:
+      case pollPaymentState.FULFILL:
         return {
           ...state,
           paymentStatePolling: {

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -8,7 +8,7 @@ import {
   submitPayment,
   fetchBasket,
   fetchActiveOrder,
-  updatePaymentState,
+  pollPaymentState,
   PAYMENT_STATE_DATA_RECEIVED,
 } from './actions';
 import { currencyDisclaimerSelector, paymentSelector } from './selectors';
@@ -230,7 +230,7 @@ describe('redux tests', () => {
       });
     });
 
-    describe('updatePaymentState actions', () => {
+    describe('pollPaymentState actions', () => {
       it('Round Trip', () => {
         const triggerStore = createStore(
           combineReducers({
@@ -252,7 +252,7 @@ describe('redux tests', () => {
           },
         );
 
-        triggerStore.dispatch(updatePaymentState());
+        triggerStore.dispatch(pollPaymentState());
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(true);
         expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.PENDING);
 
@@ -260,7 +260,7 @@ describe('redux tests', () => {
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
         expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.COMPLETED);
 
-        triggerStore.dispatch(updatePaymentState.fulfill());
+        triggerStore.dispatch(pollPaymentState.fulfill());
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
         expect(triggerStore.getState().payment.basket.paymentState === PAYMENT_STATE.PENDING).toBe(false);
       });

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -241,7 +241,7 @@ describe('redux tests', () => {
                   {
                     basket: {
                       foo: 'bar',
-                      paymentState: PAYMENT_STATE.PROCESSING,
+                      paymentState: PAYMENT_STATE.PENDING,
                       basketId: 7,
                       payments: [
                         { paymentNumber: 7 },
@@ -254,7 +254,7 @@ describe('redux tests', () => {
 
         triggerStore.dispatch(updatePaymentState());
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(true);
-        expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.PROCESSING);
+        expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.PENDING);
 
         triggerStore.dispatch({ type: PAYMENT_STATE_DATA_RECEIVED, payload: { state: PAYMENT_STATE.COMPLETED } });
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
@@ -262,7 +262,7 @@ describe('redux tests', () => {
 
         triggerStore.dispatch(updatePaymentState.fulfill());
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
-        expect(triggerStore.getState().payment.basket.paymentState === PAYMENT_STATE.PROCESSING).toBe(false);
+        expect(triggerStore.getState().payment.basket.paymentState === PAYMENT_STATE.PENDING).toBe(false);
       });
     });
   });

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -2,7 +2,8 @@ import {
   call, put, takeEvery, select, delay,
 } from 'redux-saga/effects';
 import { stopSubmit } from 'redux-form';
-import { getReduxFormValidationErrors } from './utils';
+import { getConfig } from '@edx/frontend-platform';
+import { getReduxFormValidationErrors, MINS_AS_MS, SECS_AS_MS } from './utils';
 import { MESSAGE_TYPES } from '../../feedback/data/constants';
 
 // Actions
@@ -24,6 +25,8 @@ import {
   fetchCaptureKey,
   clientSecretProcessing,
   fetchClientSecret,
+  paymentStateDataReceived,
+  updatePaymentState,
 } from './actions';
 
 import { STATUS_LOADING } from '../checkout/payment-form/flex-microform/constants';
@@ -37,6 +40,8 @@ import { checkoutWithToken } from '../payment-methods/cybersource';
 import { checkout as checkoutPaypal } from '../payment-methods/paypal';
 import { checkout as checkoutApplePay } from '../payment-methods/apple-pay';
 import { checkout as checkoutStripe } from '../payment-methods/stripe';
+import { paymentProcessStatusShouldRunSelector } from './selectors';
+import { PAYMENT_STATE } from './constants';
 
 export const paymentMethods = {
   cybersource: checkoutWithToken,
@@ -139,12 +144,15 @@ export function* handleFetchActiveOrder() {
   } finally {
     yield put(basketProcessing(false)); // we are done modifying the basket
     yield put(fetchActiveOrder.fulfill()); // mark the basket as finished loading
+    if (yield select((state) => paymentProcessStatusShouldRunSelector(state))) {
+      yield put(updatePaymentState());
+    }
   }
 }
 
 export function* handleCaptureKeyTimeout() {
   // Start at the 12min mark to leave 1 min of buffer on the 15min timeout
-  yield delay(12 * 60 * 1000);
+  yield delay(MINS_AS_MS(12));
   yield call(
     handleMessages,
     [{
@@ -155,7 +163,7 @@ export function* handleCaptureKeyTimeout() {
     window.location.search,
   );
 
-  yield delay(1 * 60 * 1000);
+  yield delay(MINS_AS_MS(1));
   yield call(
     handleMessages,
     [{
@@ -166,7 +174,7 @@ export function* handleCaptureKeyTimeout() {
     window.location.search,
   );
 
-  yield delay(1 * 60 * 1000);
+  yield delay(MINS_AS_MS(1));
   yield put(clearMessages());
   yield put(fetchCaptureKey());
 }
@@ -263,10 +271,15 @@ export function* handleSubmitPayment({ payload }) {
     yield put(basketProcessing(true));
     yield put(clearMessages()); // Don't leave messages floating on the page after clicking submit
     yield put(submitPayment.request());
+
     const paymentMethodCheckout = paymentMethods[method];
     const basket = yield select(state => ({ ...state.payment.basket }));
     yield call(paymentMethodCheckout, basket, paymentArgs);
     yield put(submitPayment.success());
+
+    if (yield select((state) => paymentProcessStatusShouldRunSelector(state))) {
+      yield put(updatePaymentState());
+    }
   } catch (error) {
     // Do not handle errors on user aborted actions
     if (!error.aborted) {
@@ -290,6 +303,53 @@ export function* handleSubmitPayment({ payload }) {
   }
 }
 
+/**
+ * Redux handler for payment status polling and updates
+ *
+ * Note:
+ *  - This handler/worker loops until it is told to stop. via a state property (keepPolling), or a fatal state.
+ */
+export function* handlePaymentState() {
+  const DEFAULT_DELAY_SECS = 5;
+  let keepPolling = true;
+
+  // noinspection JSUnresolvedReference
+  const delaySecs = getConfig().PAYMENT_STATE_POLLING_DELAY_SECS || DEFAULT_DELAY_SECS;
+
+  // NOTE: We may want to have a max errors check and have a fail state if there's a bad connection or something.
+
+  while (keepPolling) {
+    try {
+      const basketId = yield select(state => state.payment.basket.basketId);
+      const paymentNumber = yield select(state => (state.payment.basket.payments.length === 0
+        ? null : state.payment.basket.payments[0].paymentNumber));
+
+      if (!basketId || !paymentNumber) {
+        // This shouldn't happen.
+        //   I don't think we need to banner... shouldn't our parent calls recover? (They invoke this)
+        keepPolling = false;
+        yield put(updatePaymentState.fulfill());
+        return;
+      }
+
+      const result = yield call(PaymentApiService.getCurrentPaymentState, paymentNumber, basketId);
+      yield put(paymentStateDataReceived(result));
+
+      if (!(yield select(state => state.payment.basket.paymentStatePolling.keepPolling))) {
+        keepPolling = false;
+        yield put(updatePaymentState.fulfill());
+      } else {
+        yield delay(SECS_AS_MS(delaySecs));
+      }
+    } catch (error) {
+      // We dont quit on error.
+      // yield call(handleErrors, error, true);
+      yield put(paymentStateDataReceived({ state: PAYMENT_STATE.HTTP_ERROR }));
+      yield delay(SECS_AS_MS(delaySecs));
+    }
+  }
+}
+
 export default function* saga() {
   yield takeEvery(fetchCaptureKey.TRIGGER, handleFetchCaptureKey);
   yield takeEvery(CAPTURE_KEY_START_TIMEOUT, handleCaptureKeyTimeout);
@@ -300,4 +360,5 @@ export default function* saga() {
   yield takeEvery(removeCoupon.TRIGGER, handleRemoveCoupon);
   yield takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity);
   yield takeEvery(submitPayment.TRIGGER, handleSubmitPayment);
+  yield takeEvery(updatePaymentState.TRIGGER, handlePaymentState);
 }

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -26,7 +26,7 @@ import {
   clientSecretProcessing,
   fetchClientSecret,
   paymentStateDataReceived,
-  updatePaymentState,
+  pollPaymentState,
 } from './actions';
 
 import { STATUS_LOADING } from '../checkout/payment-form/flex-microform/constants';
@@ -145,7 +145,7 @@ export function* handleFetchActiveOrder() {
     yield put(basketProcessing(false)); // we are done modifying the basket
     yield put(fetchActiveOrder.fulfill()); // mark the basket as finished loading
     if (yield select((state) => paymentProcessStatusShouldRunSelector(state))) {
-      yield put(updatePaymentState());
+      yield put(pollPaymentState());
     }
   }
 }
@@ -278,7 +278,7 @@ export function* handleSubmitPayment({ payload }) {
     yield put(submitPayment.success());
 
     if (yield select((state) => paymentProcessStatusShouldRunSelector(state))) {
-      yield put(updatePaymentState());
+      yield put(pollPaymentState());
     }
   } catch (error) {
     // Do not handle errors on user aborted actions
@@ -328,7 +328,7 @@ export function* handlePaymentState() {
         // This shouldn't happen.
         //   I don't think we need to banner... shouldn't our parent calls recover? (They invoke this)
         keepPolling = false;
-        yield put(updatePaymentState.fulfill());
+        yield put(pollPaymentState.fulfill());
         return;
       }
 
@@ -337,7 +337,7 @@ export function* handlePaymentState() {
 
       if (!(yield select(state => state.payment.basket.paymentStatePolling.keepPolling))) {
         keepPolling = false;
-        yield put(updatePaymentState.fulfill());
+        yield put(pollPaymentState.fulfill());
       } else {
         yield delay(SECS_AS_MS(delaySecs));
       }
@@ -360,5 +360,5 @@ export default function* saga() {
   yield takeEvery(removeCoupon.TRIGGER, handleRemoveCoupon);
   yield takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity);
   yield takeEvery(submitPayment.TRIGGER, handleSubmitPayment);
-  yield takeEvery(updatePaymentState.TRIGGER, handlePaymentState);
+  yield takeEvery(pollPaymentState.TRIGGER, handlePaymentState);
 }

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -682,7 +682,7 @@ describe('saga tests', () => {
                 payment: {
                   basket: {
                     foo: 'bar',
-                    paymentState: PAYMENT_STATE.PROCESSING,
+                    paymentState: PAYMENT_STATE.PENDING,
                     basketId: 7,
                     payments: [
                       { paymentNumber: 7 },

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -33,7 +33,7 @@ import {
   submitPayment,
   CAPTURE_KEY_START_TIMEOUT,
   fetchClientSecret,
-  updatePaymentState,
+  pollPaymentState,
 } from './actions';
 import { clearMessages, MESSAGE_TYPES, addMessage } from '../../feedback';
 
@@ -633,7 +633,7 @@ describe('saga tests', () => {
         //   We reset it back after each run so future tests do not explode.
         nativeGlobalLocation = global.location;
         delete global.location;
-        global.location = jest.fn();// = Object.create(window);
+        global.location = jest.fn();
       });
 
       afterEach(() => {
@@ -703,7 +703,7 @@ describe('saga tests', () => {
           clearMessages(),
           submitPayment.request(),
           submitPayment.success(),
-          updatePaymentState.trigger(),
+          pollPaymentState.trigger(),
           basketProcessing(false),
           submitPayment.fulfill(),
         ]);
@@ -927,7 +927,7 @@ describe('saga tests', () => {
     expect(gen.next().value).toEqual(takeEvery(removeCoupon.TRIGGER, handleRemoveCoupon));
     expect(gen.next().value).toEqual(takeEvery(updateQuantity.TRIGGER, handleUpdateQuantity));
     expect(gen.next().value).toEqual(takeEvery(submitPayment.TRIGGER, handleSubmitPayment));
-    expect(gen.next().value).toEqual(takeEvery(updatePaymentState.TRIGGER, handlePaymentState));
+    expect(gen.next().value).toEqual(takeEvery(pollPaymentState.TRIGGER, handlePaymentState));
 
     // If you find yourself adding something here, there are probably more tests to write!
 

--- a/src/payment/data/selectors.js
+++ b/src/payment/data/selectors.js
@@ -2,6 +2,7 @@ import { getQueryParameters } from '@edx/frontend-platform';
 import { createSelector } from 'reselect';
 import { localizedCurrencySelector } from './utils';
 import { DEFAULT_STATUS } from '../checkout/payment-form/flex-microform/constants';
+import { POLLING_PAYMENT_STATES } from './constants';
 
 export const storeName = 'payment';
 
@@ -76,6 +77,27 @@ export const updateClientSecretSelector = createSelector(
   }),
 );
 
-// TODO: We may want to store the server side enum value rather than just a boolean. As such the dialog was coded this
-//  way. And we translate.
-export const paymentProcessStatusSelector = state => (state[storeName].basket.isBasketProcessing ? 'pending' : 'not');
+/**
+ * Get the current payment processing state
+ * @see PAYMENT_STATE
+ * @param  {*} state global redux state
+ * @return {string} a valid value from PAYMENT_STATE
+ */
+export const paymentProcessStatusSelector = state => (state[storeName].basket.paymentState);
+
+/**
+ * Determine if the current state warrants a run of the Payment Sate Polling Mechanism
+ * @param state
+ * @return boolean
+ * @see POLLING_PAYMENT_STATES
+ */
+export const paymentProcessStatusShouldRunSelector = state => (
+  POLLING_PAYMENT_STATES.includes(paymentProcessStatusSelector(state))
+);
+
+/**
+ * Selector to see if the Payment Status Polling system is running.
+ * @param state global redux state
+ * @return {boolean}
+ */
+export const paymentProcessStatusIsPollingSelector = state => (state[storeName].basket.paymentStatePolling.keepPolling);

--- a/src/payment/data/service.js
+++ b/src/payment/data/service.js
@@ -7,7 +7,6 @@ import { transformResults } from './utils';
 ensureConfig([
   'ECOMMERCE_BASE_URL',
   'LMS_BASE_URL',
-  'COMMERCE_COORDINATOR_BASE_URL',
 ], 'payment API service');
 
 function handleBasketApiError(requestError) {
@@ -53,7 +52,7 @@ export async function getBasket(discountJwt) {
 export async function getActiveOrder() {
   const { data } = await getAuthenticatedHttpClient()
     // .get(`${getConfig().COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/`)
-    .get(`${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/`)
+    .get(`${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/active/`)
     .catch(handleBasketApiError);
   return transformResults(data);
 }
@@ -92,5 +91,21 @@ export async function getDiscountData(courseKey) {
       withCredentials: true,
     },
   );
+  return data;
+}
+
+export async function getCurrentPaymentState(paymentNumber, basketId) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(
+      `${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/payment`,
+      {
+        params:
+          {
+            payment_number: paymentNumber,
+            order_uuid: basketId,
+          },
+      },
+    )
+    .catch(handleBasketApiError);
   return data;
 }

--- a/src/payment/data/utils.js
+++ b/src/payment/data/utils.js
@@ -228,3 +228,44 @@ export const getPropsToRemoveFractionZeroDigits = ({ price, shouldRemoveFraction
   }
   return props;
 };
+
+/**
+ * Convert Minutes to Milliseconds
+ * @param x Minutes
+ * @return {number} Milliseconds
+ */
+export const MINS_AS_MS = (x = 0) => x * 60 * 1000;
+
+/**
+ * Convert Seconds to Milliseconds
+ * @param x Seconds
+ * @return {number} Milliseconds
+ */
+export const SECS_AS_MS = (x = 0) => x * 1000;
+
+/**
+ * Chain Reducers allows more than one reducer to alter state before the store modifications are accepted.
+ *
+ * Literally, if we only have one reducer, we return it (wrapping would be useless),
+ *    otherwise we reduce our reducers.
+ *
+ * If you didn't provide any, we return undefined... and i bet React/Redux will be annoyed.
+ *
+ * @param reducers Reducers to loop through sharing state changes from the last in the list as input.
+ * @return A common reducer, so Redux allows independent ones to share state slots
+ */
+export const chainReducers = (reducers) => {
+  switch (reducers.length) {
+    case 0:
+      return undefined;
+    case 1:
+      return reducers[0];
+    default: /* No-op, lets continue execution */ break;
+  }
+
+  // if we name this it might be clearer when debugging, TODO: GRM: float the idea.
+  return (initialState, action) => reducers.reduce(
+    (lastState, reducerFn) => reducerFn(lastState, action),
+    initialState,
+  );
+};

--- a/src/payment/data/utils.js
+++ b/src/payment/data/utils.js
@@ -263,9 +263,13 @@ export const chainReducers = (reducers) => {
     default: /* No-op, lets continue execution */ break;
   }
 
-  // if we name this it might be clearer when debugging, TODO: GRM: float the idea.
-  return (initialState, action) => reducers.reduce(
-    (lastState, reducerFn) => reducerFn(lastState, action),
-    initialState,
-  );
+  // Using a function so someone with a debugger doesn't see infinite anonymous functions
+  return function _wrappedSerialChainReducers(initialState, action) {
+    // This loops through the array of reducers, by reducing the array.
+    //     The return of the inner reducerFn becomes the lastState for the next.
+    return reducers.reduce(
+      (lastState, reducerFn) => reducerFn(lastState, action),
+      initialState,
+    );
+  };
 };


### PR DESCRIPTION
- feat: THES-105: Payment State Polling
    Payment State polling on Submit Payment and Get Active Order, with a normally non-closeable Dialog.
- fix: Advisories permitted for the moment
    This spawned REV-3598.
- fix: Removal of PAYMENT_STATE.PROCESSING, this state is internal to the Titan backend.