### PR TITLE
feat: Payment State Polling Error Handling

### DIFF
--- a/src/feedback/data/constants.js
+++ b/src/feedback/data/constants.js
@@ -12,3 +12,9 @@ export const MESSAGE_TYPES = {
   WARNING: 'warning',
   ERROR: 'error',
 };
+
+export const ERROR_CODES = {
+  FALLBACK: 'fallback-error',
+  BASKET_CHANGED: 'basket-changed-error-message',
+  TRANSACTION_DECLINED: 'transaction-declined-message',
+};

--- a/src/feedback/data/sagas.js
+++ b/src/feedback/data/sagas.js
@@ -2,7 +2,7 @@ import { put } from 'redux-saga/effects';
 
 import { logError, logInfo } from '@edx/frontend-platform/logging';
 import { addMessage, clearMessages } from './actions';
-import { MESSAGE_TYPES } from './constants';
+import { ERROR_CODES, MESSAGE_TYPES } from './constants';
 
 export function* handleErrors(e, clearExistingMessages) {
   if (clearExistingMessages) {
@@ -11,15 +11,15 @@ export function* handleErrors(e, clearExistingMessages) {
 
   // If this doesn't contain anything we understand, add a fallback error message
   if (e.errors === undefined && e.fieldErrors === undefined && e.messages === undefined) {
-    yield put(addMessage('fallback-error', null, {}, MESSAGE_TYPES.ERROR));
+    yield put(addMessage(ERROR_CODES.FALLBACK, null, {}, MESSAGE_TYPES.ERROR));
   }
   if (e.errors !== undefined) {
     for (let i = 0; i < e.errors.length; i++) { // eslint-disable-line no-plusplus
       const error = e.errors[i];
-      if (error.code === 'basket-changed-error-message') {
+      if (error.code === ERROR_CODES.BASKET_CHANGED) {
         yield put(addMessage(error.code, error.userMessage, {}, MESSAGE_TYPES.ERROR));
       } else if (error.data === undefined && error.messageType === null) {
-        yield put(addMessage('transaction-declined-message', error.userMessage, {}, MESSAGE_TYPES.ERROR));
+        yield put(addMessage(ERROR_CODES.TRANSACTION_DECLINED, error.userMessage, {}, MESSAGE_TYPES.ERROR));
       } else {
         yield put(addMessage(error.code, error.userMessage, error.data, error.messageType));
       }

--- a/src/payment/PaymentProcessingModal.test.jsx
+++ b/src/payment/PaymentProcessingModal.test.jsx
@@ -28,8 +28,8 @@ const basketStoreGenerator = (paymentState = PAYMENT_STATE.DEFAULT, keepPolling 
         /** state specific to paymentStatePolling */
         paymentStatePolling: {
           // eslint-disable-next-line object-shorthand
-          keepPolling: keepPolling, // TODO: GRM: FIX both debugging items (this is one)
-          counter: 5, // debugging
+          keepPolling: keepPolling,
+          counter: 5,
         },
       },
       clientSecret: { isClientSecretProcessing: false, clientSecretId: '' },

--- a/src/payment/data/__snapshots__/redux.test.js.snap
+++ b/src/payment/data/__snapshots__/redux.test.js.snap
@@ -8,6 +8,7 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
+      "errorCount": 5,
       "keepPolling": false,
     },
     "products": Array [],
@@ -34,6 +35,7 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
+      "errorCount": 5,
       "keepPolling": false,
     },
     "products": Array [],
@@ -60,6 +62,7 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
+      "errorCount": 5,
       "keepPolling": false,
     },
     "products": Array [],

--- a/src/payment/data/__snapshots__/redux.test.js.snap
+++ b/src/payment/data/__snapshots__/redux.test.js.snap
@@ -8,8 +8,8 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
-      "errorCount": 5,
       "keepPolling": false,
+      "retryCount": 5,
     },
     "products": Array [],
     "redirect": false,
@@ -35,8 +35,8 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
-      "errorCount": 5,
       "keepPolling": false,
+      "retryCount": 5,
     },
     "products": Array [],
     "redirect": false,
@@ -62,8 +62,8 @@ Object {
     "loading": true,
     "paymentState": "checkout",
     "paymentStatePolling": Object {
-      "errorCount": 5,
       "keepPolling": false,
+      "retryCount": 5,
     },
     "products": Array [],
     "redirect": false,

--- a/src/payment/data/__snapshots__/redux.test.js.snap
+++ b/src/payment/data/__snapshots__/redux.test.js.snap
@@ -9,7 +9,7 @@ Object {
     "paymentState": "checkout",
     "paymentStatePolling": Object {
       "keepPolling": false,
-      "retryCount": 5,
+      "retriesLeft": 5,
     },
     "products": Array [],
     "redirect": false,
@@ -36,7 +36,7 @@ Object {
     "paymentState": "checkout",
     "paymentStatePolling": Object {
       "keepPolling": false,
-      "retryCount": 5,
+      "retriesLeft": 5,
     },
     "products": Array [],
     "redirect": false,
@@ -63,7 +63,7 @@ Object {
     "paymentState": "checkout",
     "paymentStatePolling": Object {
       "keepPolling": false,
-      "retryCount": 5,
+      "retriesLeft": 5,
     },
     "products": Array [],
     "redirect": false,

--- a/src/payment/data/actions.js
+++ b/src/payment/data/actions.js
@@ -1,4 +1,5 @@
 import { createRoutine } from 'redux-saga-routines';
+import { createCustomRoutine } from './utils';
 
 // Routines are action + action creator pairs in a series.
 // Actions adhere to the flux standard action format.
@@ -10,8 +11,11 @@ import { createRoutine } from 'redux-saga-routines';
 // fetchBasket.SUCCESS   |   fetchBasket.success()
 // fetchBasket.FAILURE   |   fetchBasket.failure()
 // fetchBasket.FULFILL   |   fetchBasket.fulfill()
+// fetchBasket.REQUEST   |   fetchBasket.request()
+// fetchBasket.<CUSTOM>  |   fetchBasket.<custom>()
 //
 // Created with redux-saga-routines
+
 export const fetchCaptureKey = createRoutine('FETCH_CAPTURE_KEY');
 export const fetchClientSecret = createRoutine('FETCH_CLIENT_SECRET');
 export const submitPayment = createRoutine('SUBMIT_PAYMENT');
@@ -20,7 +24,7 @@ export const fetchActiveOrder = createRoutine('FETCH_ACTIVE_ORDER');
 export const addCoupon = createRoutine('ADD_COUPON');
 export const removeCoupon = createRoutine('REMOVE_COUPON');
 export const updateQuantity = createRoutine('UPDATE_QUANTITY');
-export const pollPaymentState = createRoutine('UPDATE_PAYMENT_STATE');
+export const pollPaymentState = createCustomRoutine('UPDATE_PAYMENT_STATE', ['RECEIVED']);
 
 // Actions and their action creators
 export const BASKET_DATA_RECEIVED = 'BASKET_DATA_RECEIVED';
@@ -75,11 +79,4 @@ export const CLIENT_SECRET_DATA_RECEIVED = 'CLIENT_SECRET_DATA_RECEIVED';
 export const clientSecretDataReceived = clientSecret => ({
   type: CLIENT_SECRET_DATA_RECEIVED,
   payload: clientSecret,
-});
-
-export const PAYMENT_STATE_DATA_RECEIVED = 'PAYMENT_STATE_DATA_RECEIVED';
-
-export const paymentStateDataReceived = paymentState => ({
-  type: PAYMENT_STATE_DATA_RECEIVED,
-  payload: paymentState,
 });

--- a/src/payment/data/constants.js
+++ b/src/payment/data/constants.js
@@ -63,3 +63,19 @@ export const POLLING_PAYMENT_STATES = [
   PAYMENT_STATE.PENDING,
   PAYMENT_STATE.HTTP_ERROR,
 ];
+
+/**
+ *
+ * @type {number}
+ *
+ * This can be configured by setting `PAYMENT_STATE_POLLING_DELAY_SECS` in your config.
+ */
+export const DEFAULT_PAYMENT_STATE_POLLING_DELAY_SECS = 5;
+
+/**
+ *
+ * @type {number}
+ *
+ * This can be configured by setting `PAYMENT_STATE_POLLING_MAX_ERRORS` in your config.
+ */
+export const DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS = 5;

--- a/src/payment/data/constants.js
+++ b/src/payment/data/constants.js
@@ -65,17 +65,19 @@ export const POLLING_PAYMENT_STATES = [
 ];
 
 /**
+ * Default Delay between rounds of Payment State Polling
  *
  * @type {number}
  *
- * This can be configured by setting `PAYMENT_STATE_POLLING_DELAY_SECS` in your config.
+ * > Note: This can be configured by setting `PAYMENT_STATE_POLLING_DELAY_SECS` in your config.
  */
 export const DEFAULT_PAYMENT_STATE_POLLING_DELAY_SECS = 5;
 
 /**
+ * Default number of maximum HTTP errors before give up
  *
  * @type {number}
  *
- * This can be configured by setting `PAYMENT_STATE_POLLING_MAX_ERRORS` in your config.
+ * > Note: This can be configured by setting `PAYMENT_STATE_POLLING_MAX_ERRORS` in your config.
  */
 export const DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS = 5;

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -9,7 +9,6 @@ import {
   CLIENT_SECRET_DATA_RECEIVED,
   CLIENT_SECRET_PROCESSING,
   MICROFORM_STATUS,
-  PAYMENT_STATE_DATA_RECEIVED,
   fetchBasket,
   submitPayment,
   fetchCaptureKey,
@@ -197,7 +196,7 @@ const paymentState = (state = basketInitialState, action = null) => {
           },
         };
 
-      case PAYMENT_STATE_DATA_RECEIVED:
+      case pollPaymentState.RECEIVED:
         return {
           ...state,
           paymentState: action.payload.state,

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -196,17 +196,19 @@ const paymentState = (state = basketInitialState, action = null) => {
           },
         };
 
-      case pollPaymentState.RECEIVED:
+      case pollPaymentState.RECEIVED: {
+        const isHttpError = action.payload.state === PAYMENT_STATE.HTTP_ERROR;
+        const currErrorCount = (isHttpError ? state.paymentStatePolling.errorCount - 1 : maxErrors);
         return {
           ...state,
           paymentState: action.payload.state,
           paymentStatePolling: {
             ...state.paymentStatePolling,
-            keepPolling: shouldPoll(action.payload.state),
-            errorCount: (action.payload.state === PAYMENT_STATE.HTTP_ERROR
-              ? state.paymentStatePolling.errorCount - 1 : maxErrors),
+            keepPolling: currErrorCount > 0 && shouldPoll(action.payload.state),
+            errorCount: currErrorCount,
           },
         };
+      }
 
       default:
     }

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -37,7 +37,7 @@ const paymentStatePollingInitialState = {
    * This is replaceable by a configuration value. (`PAYMENT_STATE_POLLING_MAX_ERRORS`),
    *     however, this is our default.
    */
-  retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+  retriesLeft: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
 };
 
 /**
@@ -173,7 +173,7 @@ const clientSecret = (state = clientSecretInitialState, action = null) => {
  */
 export const paymentState = (state = basketInitialState, action = null) => {
   // noinspection JSUnresolvedReference
-  const maxErrors = getConfig().PAYMENT_STATE_POLLING_MAX_ERRORS || paymentStatePollingInitialState.retryCount;
+  const maxErrors = getConfig().PAYMENT_STATE_POLLING_MAX_ERRORS || paymentStatePollingInitialState.retriesLeft;
   const shouldPoll = (payState) => POLLING_PAYMENT_STATES.includes(payState);
 
   if (action !== null && action !== undefined) {
@@ -184,7 +184,7 @@ export const paymentState = (state = basketInitialState, action = null) => {
           paymentStatePolling: {
             ...state.paymentStatePolling,
             keepPolling: shouldPoll(state.paymentState),
-            retryCount: maxErrors,
+            retriesLeft: maxErrors,
           },
         };
 
@@ -195,7 +195,7 @@ export const paymentState = (state = basketInitialState, action = null) => {
           paymentStatePolling: {
             ...state.paymentStatePolling,
             keepPolling: false,
-            retryCount: maxErrors,
+            retriesLeft: maxErrors,
           },
         };
 
@@ -205,20 +205,20 @@ export const paymentState = (state = basketInitialState, action = null) => {
           paymentStatePolling: {
             ...state.paymentStatePolling,
             keepPolling: false,
-            retryCount: maxErrors,
+            retriesLeft: maxErrors,
           },
         };
 
       case pollPaymentState.RECEIVED: {
         const isHttpError = action.payload.state === PAYMENT_STATE.HTTP_ERROR;
-        const currRetryCnt = (isHttpError ? state.paymentStatePolling.retryCount - 1 : maxErrors);
+        const currRetriesLeft = (isHttpError ? state.paymentStatePolling.retriesLeft - 1 : maxErrors);
         return {
           ...state,
           paymentState: action.payload.state,
           paymentStatePolling: {
             ...state.paymentStatePolling,
-            keepPolling: currRetryCnt > 0 && shouldPoll(action.payload.state),
-            retryCount: currRetryCnt,
+            keepPolling: currRetriesLeft > 0 && shouldPoll(action.payload.state),
+            retriesLeft: currRetriesLeft,
           },
         };
       }

--- a/src/payment/data/reducers.js
+++ b/src/payment/data/reducers.js
@@ -53,9 +53,9 @@ const basketInitialState = {
   redirect: false,
   isBasketProcessing: false,
   products: [],
-  /** Modified by both getActiveOrder and paymentStatePolling */
+  /** Modified by both getActiveOrder and pollPaymentState */
   paymentState: PAYMENT_STATE.DEFAULT,
-  /** state specific to paymentStatePolling */
+  /** state specific to pollPaymentState */
   paymentStatePolling: paymentStatePollingInitialState,
 };
 
@@ -155,7 +155,7 @@ const clientSecret = (state = clientSecretInitialState, action = null) => {
   return state;
 };
 
-const paymentState = (state = basketInitialState, action = null) => {
+export const paymentState = (state = basketInitialState, action = null) => {
   // noinspection JSUnresolvedReference
   const maxErrors = getConfig().PAYMENT_STATE_POLLING_MAX_ERRORS || paymentStatePollingInitialState.errorCount;
   const shouldPoll = (payState) => POLLING_PAYMENT_STATES.includes(payState);

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -13,7 +13,7 @@ import {
 } from './actions';
 import { currencyDisclaimerSelector, paymentSelector } from './selectors';
 import { localizedCurrencySelector } from './utils';
-import { PAYMENT_STATE } from './constants';
+import { DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS, PAYMENT_STATE } from './constants';
 
 jest.mock('universal-cookie', () => {
   class MockCookies {
@@ -114,6 +114,7 @@ describe('redux tests', () => {
           isRedirect: false,
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
+            errorCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });
@@ -138,6 +139,7 @@ describe('redux tests', () => {
           isRedirect: true, // this is also now true.
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
+            errorCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -9,7 +9,6 @@ import {
   fetchBasket,
   fetchActiveOrder,
   pollPaymentState,
-  PAYMENT_STATE_DATA_RECEIVED,
 } from './actions';
 import { currencyDisclaimerSelector, paymentSelector } from './selectors';
 import { localizedCurrencySelector } from './utils';
@@ -258,7 +257,7 @@ describe('redux tests', () => {
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(true);
         expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.PENDING);
 
-        triggerStore.dispatch({ type: PAYMENT_STATE_DATA_RECEIVED, payload: { state: PAYMENT_STATE.COMPLETED } });
+        triggerStore.dispatch(pollPaymentState.received({ state: PAYMENT_STATE.COMPLETED }));
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
         expect(triggerStore.getState().payment.basket.paymentState).toBe(PAYMENT_STATE.COMPLETED);
 

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -113,7 +113,7 @@ describe('redux tests', () => {
           isRedirect: false,
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
-            errorCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+            retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });
@@ -138,7 +138,7 @@ describe('redux tests', () => {
           isRedirect: true, // this is also now true.
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
-            errorCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+            retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });
@@ -293,12 +293,12 @@ describe('redux tests', () => {
           triggerStore.dispatch(pollPaymentState.received({ state: PAYMENT_STATE.HTTP_ERROR }));
           expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling)
             .toBe(expectedCount > 0);
-          expect(triggerStore.getState().payment.basket.paymentStatePolling.errorCount)
+          expect(triggerStore.getState().payment.basket.paymentStatePolling.retryCount)
             .toBe(expectedCount);
         }
 
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
-        expect(triggerStore.getState().payment.basket.paymentStatePolling.errorCount)
+        expect(triggerStore.getState().payment.basket.paymentStatePolling.retryCount)
           .toBe(0);
 
         triggerStore.dispatch(pollPaymentState.failure(Error('Too many HTTP errors!')));

--- a/src/payment/data/redux.test.js
+++ b/src/payment/data/redux.test.js
@@ -113,7 +113,7 @@ describe('redux tests', () => {
           isRedirect: false,
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
-            retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+            retriesLeft: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });
@@ -138,7 +138,7 @@ describe('redux tests', () => {
           isRedirect: true, // this is also now true.
           paymentState: PAYMENT_STATE.DEFAULT,
           paymentStatePolling: {
-            retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+            retriesLeft: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
             keepPolling: false,
           },
         });
@@ -293,12 +293,12 @@ describe('redux tests', () => {
           triggerStore.dispatch(pollPaymentState.received({ state: PAYMENT_STATE.HTTP_ERROR }));
           expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling)
             .toBe(expectedCount > 0);
-          expect(triggerStore.getState().payment.basket.paymentStatePolling.retryCount)
+          expect(triggerStore.getState().payment.basket.paymentStatePolling.retriesLeft)
             .toBe(expectedCount);
         }
 
         expect(triggerStore.getState().payment.basket.paymentStatePolling.keepPolling).toBe(false);
-        expect(triggerStore.getState().payment.basket.paymentStatePolling.retryCount)
+        expect(triggerStore.getState().payment.basket.paymentStatePolling.retriesLeft)
           .toBe(0);
 
         triggerStore.dispatch(pollPaymentState.failure(Error('Too many HTTP errors!')));

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -368,9 +368,9 @@ export function* handlePaymentState() {
 
         yield put(pollPaymentState.received({ state: PAYMENT_STATE.HTTP_ERROR }));
 
-        const currentRetryCount = yield select(state => state.payment.basket.paymentStatePolling.retryCount);
+        const retriesLeft = yield select(state => state.payment.basket.paymentStatePolling.retriesLeft);
 
-        if (currentRetryCount === 0) {
+        if (retriesLeft === 0) {
           // noinspection ExceptionCaughtLocallyJS
           throw innerError;
         }

--- a/src/payment/data/sagas.js
+++ b/src/payment/data/sagas.js
@@ -26,7 +26,6 @@ import {
   fetchCaptureKey,
   clientSecretProcessing,
   fetchClientSecret,
-  paymentStateDataReceived,
   pollPaymentState,
 } from './actions';
 
@@ -335,7 +334,8 @@ export function* handlePaymentState() {
         }
 
         const result = yield call(PaymentApiService.getCurrentPaymentState, paymentNumber, basketId);
-        yield put(paymentStateDataReceived(result));
+
+        yield put(pollPaymentState.received(result));
 
         if (!(yield select(state => state.payment.basket.paymentStatePolling.keepPolling))) {
           yield put(pollPaymentState.fulfill());
@@ -354,7 +354,7 @@ export function* handlePaymentState() {
           throw innerError;
         }
 
-        yield put(paymentStateDataReceived({ state: PAYMENT_STATE.HTTP_ERROR }));
+        yield put(pollPaymentState.received({ state: PAYMENT_STATE.HTTP_ERROR }));
 
         if (yield select(state => state.payment.basket.paymentStatePolling.errorCount) < 1) {
           // noinspection ExceptionCaughtLocallyJS

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -885,7 +885,7 @@ describe('saga tests', () => {
       paymentState: inPaymentState,
       paymentStatePolling: {
         keepPolling: false,
-        retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+        retriesLeft: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
       },
     });
 

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -885,7 +885,7 @@ describe('saga tests', () => {
       paymentState: inPaymentState,
       paymentStatePolling: {
         keepPolling: false,
-        errorCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
+        retryCount: DEFAULT_PAYMENT_STATE_POLLING_MAX_ERRORS,
       },
     });
 

--- a/src/payment/data/sagas.test.js
+++ b/src/payment/data/sagas.test.js
@@ -52,8 +52,7 @@ const axiosMock = new MockAdapter(axios);
 getAuthenticatedHttpClient.mockReturnValue(axios);
 
 const BASKET_API_ENDPOINT = `${getConfig().ECOMMERCE_BASE_URL}/bff/payment/v0/payment/`;
-// const CC_ORDER_API_ENDPOINT = `${getConfig().COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/`;
-const CC_ORDER_API_ENDPOINT = `${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/active/`;
+const CC_ORDER_API_ENDPOINT = `${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/active`;
 const DISCOUNT_API_ENDPOINT = `${getConfig().LMS_BASE_URL}/api/discounts/course/`;
 const COUPON_API_ENDPOINT = `${getConfig().ECOMMERCE_BASE_URL}/bff/payment/v0/vouchers/`;
 const QUANTITY_API_ENDPOINT = `${getConfig().ECOMMERCE_BASE_URL}/bff/payment/v0/quantity/`;

--- a/src/payment/data/service.js
+++ b/src/payment/data/service.js
@@ -50,9 +50,9 @@ export async function getBasket(discountJwt) {
 }
 
 export async function getActiveOrder() {
+  // This call cant end in `/` or it fails to pattern match in CC
   const { data } = await getAuthenticatedHttpClient()
-    // .get(`${getConfig().COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/`)
-    .get(`${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/active/`)
+    .get(`${process.env.COMMERCE_COORDINATOR_BASE_URL}/frontend-app-payment/order/active`)
     .catch(handleBasketApiError);
   return transformResults(data);
 }

--- a/src/payment/data/utils.js
+++ b/src/payment/data/utils.js
@@ -2,6 +2,7 @@ import camelCase from 'lodash.camelcase';
 import snakeCase from 'lodash.snakecase';
 import { getConfig } from '@edx/frontend-platform';
 import Cookies from 'universal-cookie';
+import { createRoutineCreator, defaultRoutineStages } from 'redux-saga-routines';
 import { ORDER_TYPES } from './constants';
 
 export function modifyObjectKeys(object, modify) {
@@ -273,3 +274,17 @@ export const chainReducers = (reducers) => {
     );
   };
 };
+
+/**
+ * Create a Routine with Custom Steps
+ * @param {string} name Name of the Routine
+ * @param {string[]} addtlStages An Array of Additional Steps (these will be uppercased)
+ * @param {boolean=} keepDefaults If we should include the normal Routine Steps
+ * @returns {*} A Redux Saga Routine
+ */
+export function createCustomRoutine(name, addtlStages, keepDefaults = true) {
+  return createRoutineCreator([
+    ...(keepDefaults ? defaultRoutineStages : []),
+    ...addtlStages.map(x => x.toUpperCase()),
+  ])(name);
+}

--- a/src/payment/data/utils.test.js
+++ b/src/payment/data/utils.test.js
@@ -1,6 +1,7 @@
 import { Factory } from 'rosie';
 import '../__factories__/basket.factory';
 
+import { defaultRoutineStages } from 'redux-saga-routines';
 import { ORDER_TYPES } from './constants';
 import {
   AsyncActionType,
@@ -17,6 +18,7 @@ import {
   SECS_AS_MS,
   MINS_AS_MS,
   chainReducers,
+  createCustomRoutine,
 } from './utils';
 
 describe('modifyObjectKeys', () => {
@@ -369,4 +371,51 @@ describe('chainReducers([reducers])', () => {
     expect(firstStateResult.first_reducer_value).toEqual(SET_VALUE);
     expect(firstStateResult.second_reducer_value).toEqual(undefined);
   });
+});
+
+describe('createCustomRoutine', () => {
+  const tests = [
+    {
+      name: 'Additional Stage (UC) + Inherts Default Stages',
+      params: { name: 'TEST_ROUTINE_1', addtlStages: ['MEOW'], inheritDefaults: true },
+    },
+    {
+      name: 'Additional Stage (LC) + Inherts Default Stages',
+      params: { name: 'TEST_ROUTINE_2', addtlStages: ['meow'], inheritDefaults: true },
+    },
+    {
+      name: 'Additional Stage (LC) + Doesnt Inherit Default Stages',
+      params: { name: 'TEST_ROUTINE_3', addtlStages: ['woof'], inheritDefaults: false },
+    },
+  ];
+
+  for (let i = 0, testPlan = tests[i]; i < tests.length; i++, testPlan = tests[i]) {
+    it(testPlan.name, () => {
+      /* eslint-disable no-underscore-dangle */ // We don't control the fact that we have to access _ props here.
+      const routineUnderTest = createCustomRoutine(
+        testPlan.params.name,
+        testPlan.params.addtlStages,
+        testPlan.params.inheritDefaults,
+      );
+
+      expect(routineUnderTest._PREFIX).toEqual(testPlan.params.name);
+
+      for (let si = 0, stageName = defaultRoutineStages[si];
+        si < defaultRoutineStages.length;
+        si++, stageName = defaultRoutineStages[si]) {
+        if (testPlan.params.inheritDefaults) {
+          expect(routineUnderTest._STAGES).toContain(stageName);
+        } else {
+          expect(routineUnderTest._STAGES).not.toContain(stageName);
+        }
+      }
+
+      for (let si = 0, stageName = testPlan.params.addtlStages[si];
+        si < testPlan.params.addtlStages.length;
+        si++, stageName = testPlan.params.addtlStages[si]) {
+        expect(routineUnderTest._STAGES).toContain(stageName.toUpperCase());
+      }
+      /* eslint-enable no-underscore-dangle */
+    });
+  }
 });


### PR DESCRIPTION
Per THES-216:
- Adding 5 failures for HTTP issues, then we show a banner
- Fatal Errors fail and show banner immediately
- Semi-integration test between reducer and handler for polling and its various error states.

Also:
- Documentation Updates
- Constants for Error Handling
- Ability to generate an API Error without automatically throwing
- Updated the polling event mechanism to use a custom routine
