### PR TITLE
feat: 3DS checkout flow for subscriptions

### DIFF
--- a/src/feedback/data/sagas.js
+++ b/src/feedback/data/sagas.js
@@ -103,6 +103,7 @@ export function* handleSubscriptionErrors(e, clearExistingMessages) {
           'program_unavailable',
           'ineligible_program',
           'payment_attachment_error',
+          'requires_payment_method',
         ];
 
         if (customErrors.includes(error.code)) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -35,6 +35,7 @@ import {
   getPerformanceProperties,
 } from './payment';
 import { SubscriptionPage } from './subscription';
+import { Secure3dRedirectPage } from './subscription/secure-3d/Secure3dRedirectPage';
 
 import configureStore from './data/configureStore';
 
@@ -91,7 +92,10 @@ subscribe(APP_READY, () => {
           <Route exact path="/" component={PaymentPage} />
           {
             getConfig().ENABLE_B2C_SUBSCRIPTIONS?.toLowerCase() === 'true' ? (
-              <Route exact path="/subscription" component={SubscriptionPage} />
+              <>
+                <Route exact path="/subscription" component={SubscriptionPage} />
+                <Route exact path="/subscription/3ds" component={Secure3dRedirectPage} />
+              </>
             ) : null
           }
           <Route path="*" component={EcommerceRedirect} />

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@
 
 @import './payment/index.scss';
 @import './subscription/index.scss';
+@import './subscription/secure-3d/index.scss';
 
 @import "~@edx/frontend-component-header/dist/index";
 @import "~@edx/frontend-component-footer/dist/footer";

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -18,6 +18,7 @@ import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
 import SubscriptionSubmitButton from '../../../subscription/checkout/submit-button/SubscriptionSubmitButton';
 import MonthlyBillingNotification from '../../../subscription/checkout/monthly-billing-notification/MonthlyBillingNotification';
+import { Secure3DModal } from '../../../subscription/checkout/secure-3d-modal/Secure3dModal';
 
 import {
   getRequiredFields, validateRequiredFields, validateAsciiNames,
@@ -183,6 +184,7 @@ const StripePaymentForm = ({
             disabled={submitting}
             isProcessing={isProcessing}
           />
+          <Secure3DModal stripe={stripe} />
         </>
       ) : (
         <PlaceOrderButton

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -184,7 +184,7 @@ const StripePaymentForm = ({
             disabled={submitting}
             isProcessing={isProcessing}
           />
-          <Secure3DModal stripe={stripe} />
+          <Secure3DModal stripe={stripe} elements={elements} />
         </>
       ) : (
         <PlaceOrderButton

--- a/src/payment/checkout/payment-form/StripePaymentForm.jsx
+++ b/src/payment/checkout/payment-form/StripePaymentForm.jsx
@@ -18,7 +18,7 @@ import CardHolderInformation from './CardHolderInformation';
 import PlaceOrderButton from './PlaceOrderButton';
 import SubscriptionSubmitButton from '../../../subscription/checkout/submit-button/SubscriptionSubmitButton';
 import MonthlyBillingNotification from '../../../subscription/checkout/monthly-billing-notification/MonthlyBillingNotification';
-import { Secure3DModal } from '../../../subscription/checkout/secure-3d-modal/Secure3dModal';
+import { Secure3DModal } from '../../../subscription/secure-3d/secure-3d-modal/Secure3dModal';
 
 import {
   getRequiredFields, validateRequiredFields, validateAsciiNames,

--- a/src/subscription/alerts/ErrorMessages.jsx
+++ b/src/subscription/alerts/ErrorMessages.jsx
@@ -50,7 +50,7 @@ export const Unsuccessful3DSMessage = () => (
   <FormattedMessage
     FormattedMessage
     id="subscription.alerts.error.requires_payment_method"
-    defaultMessage="We're sorry, the details you provided could not pass the 3d secure check. Please try different payment details."
+    defaultMessage="We're sorry, the details you provided could not pass the 3D Secure check. Please try different payment details."
     description="Telling user that there was an error completing 3DS flow for purchasing a subscription."
   >
     {text => <p aria-level="2">{text}</p>}

--- a/src/subscription/alerts/ErrorMessages.jsx
+++ b/src/subscription/alerts/ErrorMessages.jsx
@@ -39,8 +39,19 @@ export const IneligibleProgramErrorMessage = () => (
   <FormattedMessage
     FormattedMessage
     id="subscription.alerts.error.ineligible_program"
-    defaultMessage="We're sorry, this program is no longer offering a subscription option. Please search our catalog for current availability"
+    defaultMessage="We're sorry, this program is no longer offering a subscription option. Please search our catalog for current availability."
     description="Telling user that this program is not available for not available for subscription anymore."
+  >
+    {text => <p aria-level="2">{text}</p>}
+  </FormattedMessage>
+);
+
+export const Unsuccessful3DSMessage = () => (
+  <FormattedMessage
+    FormattedMessage
+    id="subscription.alerts.error.requires_payment_method"
+    defaultMessage="We're sorry, the details you provided could not pass the 3d secure check. Please try different payment details."
+    description="Telling user that there was an error completing 3DS flow for purchasing a subscription."
   >
     {text => <p aria-level="2">{text}</p>}
   </FormattedMessage>

--- a/src/subscription/alerts/SubscriptionAlerts.jsx
+++ b/src/subscription/alerts/SubscriptionAlerts.jsx
@@ -9,6 +9,7 @@ import {
   EmbargoErrorMessage,
   ProgramUnavailableMessage,
   IneligibleProgramErrorMessage,
+  Unsuccessful3DSMessage,
 } from './ErrorMessages';
 
 /**
@@ -24,6 +25,7 @@ export const SubscriptionAlerts = () => (
       program_unavailable: (<ProgramUnavailableMessage />),
       ineligible_program: (<IneligibleProgramErrorMessage />),
       payment_attachment_error: (<TransactionDeclined />),
+      requires_payment_method: (<Unsuccessful3DSMessage />),
     }}
   />
 );

--- a/src/subscription/checkout/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/checkout/secure-3d-modal/Secure3dModal.jsx
@@ -13,7 +13,7 @@ import { detailsSelector } from '../../data/details/selectors';
  * Secure3DModal
  * This modal implements the 3DS functionality for
  * both trial and non-trial purchases. It uses the setupIntent
- * for trial purchases and paymentIntent function for non-trial
+ * for trial and paymentIntent function for non-trial
  * purchases in order to load 3DS details inside an iFrame modal
  */
 export const Secure3DModal = ({ stripe }) => {
@@ -54,10 +54,6 @@ export const Secure3DModal = ({ stripe }) => {
       throw new Error(`Error loading 3D secure details): ${e.message}`);
     }
   };
-
-  // useEffect(() => {
-  //   loadSecureDetails('https://hooks.stripe.com/3d_secure_2/hosted?merchant=acct_1Ls7QSH4caH7G0X1&publishable_key=pk_test_51Ls7QSH4caH7G0X1prLj26IWylx2AP5vGA3nd4GMGPRXjVQlA9HATsF2aC5QhbeGNnTr2xijDLQPQzqefrMvHvke00L5eGLK4N&setup_intent=seti_1NT1qtH4caH7G0X1dWG6wrbZ&setup_intent_client_secret=seti_1NT1qtH4caH7G0X1dWG6wrbZ_secret_OFWuX8eF6y1oYQDaPcJF4GGf70jgg4B&source=src_1NT1quH4caH7G0X15pCrAdil');
-  // }, []);
 
   useEffect(() => {
     if (status === '3DS') {

--- a/src/subscription/checkout/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/checkout/secure-3d-modal/Secure3dModal.jsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  ModalDialog,
+} from '@edx/paragon';
+import { useSelector } from 'react-redux';
+
+import { subscriptionStatusSelector } from '../../data/status/selectors';
+import { detailsSelector } from '../../data/details/selectors';
+
+/**
+ * Secure3DModal
+ * This modal implements the 3DS functionality for
+ * both trial and non-trial purchases. It uses the setupIntent
+ * for trial purchases and paymentIntent function for non-trial
+ * purchases in order to load 3DS details inside an iFrame modal
+ */
+export const Secure3DModal = ({ stripe }) => {
+  const { status, confirmationClientSecret } = useSelector(subscriptionStatusSelector);
+  const { isTrialEligible } = useSelector(detailsSelector);
+  const [isOpen, setOpen] = useState(false);
+
+  const loadSecureDetails = (url) => {
+    setTimeout(() => {
+      const container = document.getElementById('secure-3ds-wrapper');
+      const iframe = document.createElement('iframe');
+      iframe.src = url;
+      iframe.width = '100%';
+      iframe.height = '100%';
+      container.appendChild(iframe);
+    });
+  };
+
+  const retrieveSetupIntent = async () => {
+    const response = await stripe.retrieveSetupIntent(confirmationClientSecret);
+    if (response.error) { throw response.error; }
+    return response.setupIntent.next_action.redirect_to_url.url;
+  };
+
+  const retrievePaymentIntent = async () => {
+    const response = await stripe.retrievePaymentIntent(confirmationClientSecret);
+    if (response.error) { throw response.error; }
+    return response.paymentIntent.next_action.redirect_to_url.url;
+  };
+
+  const fetchSecureDetails = async () => {
+    try {
+      const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
+      const secureUrl = await fetchPaymentDetails();
+      loadSecureDetails(secureUrl);
+      setOpen(true);
+    } catch (e) {
+      throw new Error(`Error loading 3D secure details): ${e.message}`);
+    }
+  };
+
+  // useEffect(() => {
+  //   loadSecureDetails('https://hooks.stripe.com/3d_secure_2/hosted?merchant=acct_1Ls7QSH4caH7G0X1&publishable_key=pk_test_51Ls7QSH4caH7G0X1prLj26IWylx2AP5vGA3nd4GMGPRXjVQlA9HATsF2aC5QhbeGNnTr2xijDLQPQzqefrMvHvke00L5eGLK4N&setup_intent=seti_1NT1qtH4caH7G0X1dWG6wrbZ&setup_intent_client_secret=seti_1NT1qtH4caH7G0X1dWG6wrbZ_secret_OFWuX8eF6y1oYQDaPcJF4GGf70jgg4B&source=src_1NT1quH4caH7G0X15pCrAdil');
+  // }, []);
+
+  useEffect(() => {
+    if (status === '3DS') {
+      fetchSecureDetails();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
+  if (!isOpen) { return null; }
+
+  return (
+    <ModalDialog
+      title="3DS Modal"
+      isOpen={isOpen}
+      onClose={() => {}}
+      hasCloseButton={false}
+      isFullscreenOnMobile={false}
+      className="secure-3d-modal"
+    >
+      <div id="secure-3ds-wrapper" className="secure-3ds-wrapper" />
+    </ModalDialog>
+  );
+};
+
+Secure3DModal.propTypes = {
+  stripe: PropTypes.shape({
+    retrievePaymentIntent: () => {},
+    retrieveSetupIntent: () => {},
+  }).isRequired,
+};
+
+export default Secure3DModal;

--- a/src/subscription/data/details/details-redux.test.js
+++ b/src/subscription/data/details/details-redux.test.js
@@ -108,13 +108,13 @@ describe('subscription details redux tests', () => {
       });
     });
 
-    describe('fetchBasket actions', () => {
-      test.only('fetchBasket.TRIGGER action', () => {
+    describe('fetchSubscriptionDetails actions', () => {
+      test.only('fetchSubscriptionDetails.TRIGGER action', () => {
         store.dispatch(fetchSubscriptionDetails());
         expect(store.getState().subscription.details.loading).toBe(true);
       });
 
-      it('fetchBasket.FULFILL action', () => {
+      it('fetchSubscriptionDetails.FULFILL action', () => {
         store.dispatch(fetchSubscriptionDetails.fulfill());
         expect(store.getState().subscription.details.loading).toBe(false);
         expect(store.getState().subscription.details.loaded).toBe(true);

--- a/src/subscription/data/details/sagas.js
+++ b/src/subscription/data/details/sagas.js
@@ -79,7 +79,8 @@ export function* handleSubmitSubscription({ payload }) {
     yield put(submitSubscription.request());
     const paymentMethodCheckout = paymentMethods[method];
     const postData = yield call(paymentMethodCheckout, details, paymentArgs);
-    const result = yield call(SubscriptionApiService.postDetails, postData);
+    // sending subscription price
+    const result = yield call(SubscriptionApiService.postDetails, { ...postData, price: details.price });
 
     yield put(submitSubscription.success(result));
     yield put(subscriptionStatusReceived({ ...result, paymentMethodId: postData.payment_method_id }));

--- a/src/subscription/data/details/sagas.js
+++ b/src/subscription/data/details/sagas.js
@@ -82,7 +82,7 @@ export function* handleSubmitSubscription({ payload }) {
     const result = yield call(SubscriptionApiService.postDetails, postData);
 
     yield put(submitSubscription.success(result));
-    yield put(subscriptionStatusReceived({ ...result, payment_method_id: postData.payment_method_id }));
+    yield put(subscriptionStatusReceived({ ...result, paymentMethodId: postData.payment_method_id }));
     // success segment event
     if (result.status === 'trialing'
     || result.status === 'succeeded') {

--- a/src/subscription/data/sagas.js
+++ b/src/subscription/data/sagas.js
@@ -12,17 +12,14 @@ import {
   handleSubmitSubscription,
 } from './details/sagas';
 import {
-  handleSuccessful3DS,
-  handleUnSuccessful3DS,
+  onSuccessful3DS,
 } from './status/actions';
 import {
-  successful3DS,
-  unSuccessful3DS,
+  handleSuccessful3DS,
 } from './status/sagas';
 
 export default function* saga() {
   yield takeLatest(fetchSubscriptionDetails.TRIGGER, handleFetchSubscriptionDetails);
   yield takeLatest(submitSubscription.TRIGGER, handleSubmitSubscription);
-  yield takeLatest(handleSuccessful3DS.TRIGGER, successful3DS);
-  yield takeLatest(handleUnSuccessful3DS.TRIGGER, unSuccessful3DS);
+  yield takeLatest(onSuccessful3DS.TRIGGER, handleSuccessful3DS);
 }

--- a/src/subscription/data/sagas.js
+++ b/src/subscription/data/sagas.js
@@ -5,8 +5,11 @@ import {
 // details
 import { fetchSubscriptionDetails, submitSubscription } from './details/actions';
 import { handleFetchSubscriptionDetails, handleSubmitSubscription } from './details/sagas';
+import { sendSuccessful3DS } from './status/actions';
+import { handleSuccessful3DS } from './status/sagas';
 
 export default function* saga() {
   yield takeLatest(submitSubscription.TRIGGER, handleSubmitSubscription);
   yield takeLatest(fetchSubscriptionDetails.TRIGGER, handleFetchSubscriptionDetails);
+  yield takeLatest(sendSuccessful3DS.TRIGGER, handleSuccessful3DS);
 }

--- a/src/subscription/data/sagas.js
+++ b/src/subscription/data/sagas.js
@@ -3,13 +3,26 @@ import {
 } from 'redux-saga/effects';
 
 // details
-import { fetchSubscriptionDetails, submitSubscription } from './details/actions';
-import { handleFetchSubscriptionDetails, handleSubmitSubscription } from './details/sagas';
-import { sendSuccessful3DS } from './status/actions';
-import { handleSuccessful3DS } from './status/sagas';
+import {
+  fetchSubscriptionDetails,
+  submitSubscription,
+} from './details/actions';
+import {
+  handleFetchSubscriptionDetails,
+  handleSubmitSubscription,
+} from './details/sagas';
+import {
+  handleSuccessful3DS,
+  handleUnSuccessful3DS,
+} from './status/actions';
+import {
+  successful3DS,
+  unSuccessful3DS,
+} from './status/sagas';
 
 export default function* saga() {
-  yield takeLatest(submitSubscription.TRIGGER, handleSubmitSubscription);
   yield takeLatest(fetchSubscriptionDetails.TRIGGER, handleFetchSubscriptionDetails);
-  yield takeLatest(sendSuccessful3DS.TRIGGER, handleSuccessful3DS);
+  yield takeLatest(submitSubscription.TRIGGER, handleSubmitSubscription);
+  yield takeLatest(handleSuccessful3DS.TRIGGER, successful3DS);
+  yield takeLatest(handleUnSuccessful3DS.TRIGGER, unSuccessful3DS);
 }

--- a/src/subscription/data/service.js
+++ b/src/subscription/data/service.js
@@ -20,6 +20,12 @@ ensureConfig([
   'SUBSCRIPTIONS_BASE_URL',
 ], 'subscription API service');
 
+/**
+ * handleDetailsApiError
+ * handle the server api error and
+ * transform them into what feedback alerts
+ * should render
+ */
 export function handleDetailsApiError(requestError) {
   const errors = [];
   /* eslint-disable camelcase */
@@ -38,6 +44,11 @@ export function handleDetailsApiError(requestError) {
   throw apiError;
 }
 
+/**
+ * getDetails
+ * fetches the user cart details for subscription
+ * @returns program details
+ */
 export async function getDetails() {
   const { data } = await getAuthenticatedHttpClient()
     .get(`${getConfig().SUBSCRIPTIONS_BASE_URL}/api/v1/stripe-checkout/`)
@@ -45,10 +56,32 @@ export async function getDetails() {
   return transformSubscriptionDetails(data);
 }
 
+/**
+ * postDetails
+ * will post checkout form details details
+ * @param {object} postData
+ * @returns server response object
+ */
 export async function postDetails(postData) {
   const { data } = await getAuthenticatedHttpClient()
     .post(
       `${getConfig().SUBSCRIPTIONS_BASE_URL}/api/v1/stripe-checkout/`,
+      postData,
+    )
+    .catch(handleDetailsApiError.bind({ payload: postData }));
+  return transformSubscriptionDetails(data);
+}
+
+/**
+ * checkoutComplete
+ * notifies the successful 3ds completion
+ * @param {object} postData
+ * @returns server response object
+ */
+export async function checkoutComplete(postData) {
+  const { data } = await getAuthenticatedHttpClient()
+    .post(
+      `${getConfig().SUBSCRIPTIONS_BASE_URL}/api/v1/stripe-checkout-complete/`,
       postData,
     )
     .catch(handleDetailsApiError.bind({ payload: postData }));

--- a/src/subscription/data/service.js
+++ b/src/subscription/data/service.js
@@ -68,7 +68,10 @@ export async function postDetails(postData) {
       `${getConfig().SUBSCRIPTIONS_BASE_URL}/api/v1/stripe-checkout/`,
       postData,
     )
-    .catch(handleDetailsApiError.bind({ payload: postData }));
+    .catch(handleDetailsApiError.bind({
+      // binding the postData data so we can extract programUuid to send a SDN segment event
+      payload: postData,
+    }));
   return transformSubscriptionDetails(data);
 }
 
@@ -84,6 +87,6 @@ export async function checkoutComplete(postData) {
       `${getConfig().SUBSCRIPTIONS_BASE_URL}/api/v1/stripe-checkout-complete/`,
       postData,
     )
-    .catch(handleDetailsApiError.bind({ payload: postData }));
+    .catch(handleDetailsApiError);
   return transformSubscriptionDetails(data);
 }

--- a/src/subscription/data/status/actions.js
+++ b/src/subscription/data/status/actions.js
@@ -3,7 +3,8 @@ import { createRoutine } from 'redux-saga-routines';
 export const submit3DS = createRoutine('SUBMIT_3DS');
 
 // Actions and their action creators
-export const sendSuccessful3DS = createRoutine('SEND_SUCCESSFUL_3DS');
+export const handleSuccessful3DS = createRoutine('HANDLE_SUCCESSFUL_3DS');
+export const handleUnSuccessful3DS = createRoutine('HANDLE_UN_SUCCESSFUL_3DS');
 export const SUBSCRIPTION_STATUS_RECEIVED = 'SUBSCRIPTION_STATUS_RECEIVED';
 
 export const subscriptionStatusReceived = status => ({

--- a/src/subscription/data/status/actions.js
+++ b/src/subscription/data/status/actions.js
@@ -3,6 +3,7 @@ import { createRoutine } from 'redux-saga-routines';
 export const submit3DS = createRoutine('SUBMIT_3DS');
 
 // Actions and their action creators
+export const sendSuccessful3DS = createRoutine('SEND_SUCCESSFUL_3DS');
 export const SUBSCRIPTION_STATUS_RECEIVED = 'SUBSCRIPTION_STATUS_RECEIVED';
 
 export const subscriptionStatusReceived = status => ({

--- a/src/subscription/data/status/actions.js
+++ b/src/subscription/data/status/actions.js
@@ -3,8 +3,7 @@ import { createRoutine } from 'redux-saga-routines';
 export const submit3DS = createRoutine('SUBMIT_3DS');
 
 // Actions and their action creators
-export const handleSuccessful3DS = createRoutine('HANDLE_SUCCESSFUL_3DS');
-export const handleUnSuccessful3DS = createRoutine('HANDLE_UN_SUCCESSFUL_3DS');
+export const onSuccessful3DS = createRoutine('ON_SUCCESSFUL_3DS');
 export const SUBSCRIPTION_STATUS_RECEIVED = 'SUBSCRIPTION_STATUS_RECEIVED';
 
 export const subscriptionStatusReceived = status => ({

--- a/src/subscription/data/status/reducer.js
+++ b/src/subscription/data/status/reducer.js
@@ -7,6 +7,7 @@ export const CONFIRMATION_STATUS = {
   trialing: 'trialing',
   succeeded: 'succeeded',
   requires_action: 'requires_action',
+  requires_payment_method: 'requires_payment_method',
 };
 
 const subscriptionStatusInitialState = {
@@ -32,7 +33,16 @@ export const subscriptionStatusReducer = (state = subscriptionStatusInitialState
       case SUBSCRIPTION_STATUS_RECEIVED: return {
         ...state,
         ...action.payload,
-        status: CONFIRMATION_STATUS[action.payload.status],
+        // Checking if 3DS leads to neither `succeeded` nor `requires_payment_method`
+        // then setting status to `requires_payment_method`
+        // eslint-disable-next-line no-nested-ternary
+        status: CONFIRMATION_STATUS[action.payload.status]
+          ? CONFIRMATION_STATUS[action.payload.status] : (
+            // if 3DS was active, and empty status received setting it to `requires_payment_method`
+            state.status === CONFIRMATION_STATUS.requires_action
+              ? CONFIRMATION_STATUS.requires_payment_method
+              : null
+          ),
       };
       default:
     }

--- a/src/subscription/data/status/reducer.js
+++ b/src/subscription/data/status/reducer.js
@@ -6,7 +6,7 @@ import {
 export const CONFIRMATION_STATUS = {
   trialing: 'trialing',
   succeeded: 'succeeded',
-  requires_action: '3DS',
+  requires_action: 'requires_action',
 };
 
 const subscriptionStatusInitialState = {

--- a/src/subscription/data/status/sagas.js
+++ b/src/subscription/data/status/sagas.js
@@ -60,6 +60,9 @@ export function* unSuccessful3DS() {
       true,
     );
     // failure segment event
+    yield put(subscriptionStatusReceived({
+      status: null,
+    }));
     sendSubscriptionEvent({ details, success: false });
   } catch (error) {
     yield call(

--- a/src/subscription/data/status/sagas.js
+++ b/src/subscription/data/status/sagas.js
@@ -1,0 +1,68 @@
+import {
+  call, put, select,
+} from 'redux-saga/effects';
+
+import { sendSubscriptionEvent, handleCustomErrors } from '../utils';
+
+// Actions
+import { subscriptionStatusReceived } from './actions';
+
+// Sagas
+import { handleSubscriptionErrors, clearMessages } from '../../../feedback';
+
+// Services
+import * as SubscriptionApiService from '../service';
+
+export function* handleSuccessful3DS({ payload }) {
+  const details = yield select(state => ({ ...state.subscription.details }));
+  const status = yield select(state => ({ ...state.subscription.status }));
+  try {
+    // yield put(subscriptionDetailsProcessing(true));
+    yield put(clearMessages()); // Don't leave messages floating on the page after clicking submit
+    const postData = {
+      program_uuid: details.programUuid,
+      program_title: details.programTitle,
+      payment_method_id: status.paymentMethodId,
+      confirmation_client_secret: status.confirmationClientSecret,
+      subscription_id: status.subscription_id,
+      secure_3d_status: payload.status,
+    };
+    const result = yield call(SubscriptionApiService.checkoutComplete, postData);
+
+    // yield put(submitSubscription.success(result));
+    yield put(subscriptionStatusReceived(result));
+    // success segment event
+    sendSubscriptionEvent({ details, success: true });
+  } catch (error) {
+    yield call(handleSubscriptionErrors, error, true);
+    // failure segment event
+    sendSubscriptionEvent({ details, success: false });
+    // yield put(submitSubscription.failure());
+  }
+}
+
+export function* handleUnSuccessful3DS() {
+  const details = yield select(state => ({ ...state.subscription.details }));
+  try {
+    yield put(clearMessages()); // Don't leave messages floating on the page after clicking submit
+    yield call(
+      handleSubscriptionErrors,
+      handleCustomErrors(new Error('Could not complete 3DS', {
+        cause: 'requires_payment_method',
+      }), 'requires_payment_method'),
+      true,
+    );
+    // failure segment event
+    sendSubscriptionEvent({ details, success: false });
+  } catch (error) {
+    yield call(
+      handleSubscriptionErrors,
+      handleCustomErrors(new Error('Something went wrong.', {
+        cause: 'fallback_error',
+      }), 'fallback_error'),
+      true,
+    );
+  }
+}
+
+export default handleSuccessful3DS;

--- a/src/subscription/data/status/sagas.js
+++ b/src/subscription/data/status/sagas.js
@@ -16,63 +16,37 @@ import * as SubscriptionApiService from '../service';
 /**
  * post the successful 3DS status to stripe-checkout-complete endpoint
  */
-export function* successful3DS({ payload }) {
+export function* handleSuccessful3DS({ payload }) {
   const details = yield select(state => ({ ...state.subscription.details }));
   const status = yield select(state => ({ ...state.subscription.status }));
   try {
-    // yield put(subscriptionDetailsProcessing(true));
     yield put(clearMessages()); // Don't leave messages floating on the page after clicking submit
     const postData = {
-      program_uuid: details.programUuid,
-      program_title: details.programTitle,
-      payment_method_id: status.paymentMethodId,
       confirmation_client_secret: status.confirmationClientSecret,
       subscription_id: status.subscriptionId,
-      secure_3d_status: payload.status,
+      program_title: details.programTitle,
     };
-    yield call(SubscriptionApiService.checkoutComplete, postData);
+    const result = yield call(SubscriptionApiService.checkoutComplete, { ...payload, ...postData });
 
     yield put(subscriptionStatusReceived({
-      status: details.isTrialEligible ? 'trialing' : 'succeeded',
+      status: result.status,
     }));
+
+    if (result.status === 'requires_payment_method') {
+      throw new Error('Could not complete the payment', { cause: 'requires_payment_method' });
+    }
+
     // success segment event
     sendSubscriptionEvent({ details, success: true });
   } catch (error) {
-    yield call(handleSubscriptionErrors, error, true);
-    // failure segment event
-    sendSubscriptionEvent({ details, success: false });
-    // yield put(submitSubscription.failure());
-  }
-}
-
-/**
- * display an alert for unsuccessful 3DS status
- */
-export function* unSuccessful3DS() {
-  const details = yield select(state => ({ ...state.subscription.details }));
-  try {
-    yield put(clearMessages()); // Don't leave messages floating on the page after clicking submit
     yield call(
       handleSubscriptionErrors,
-      handleCustomErrors(new Error('Could not complete 3DS', {
-        cause: 'requires_payment_method',
-      }), 'requires_payment_method'),
+      handleCustomErrors(error, error.cause ? error.cause : 'fallback-error'),
       true,
     );
     // failure segment event
-    yield put(subscriptionStatusReceived({
-      status: null,
-    }));
     sendSubscriptionEvent({ details, success: false });
-  } catch (error) {
-    yield call(
-      handleSubscriptionErrors,
-      handleCustomErrors(new Error('Something went wrong.', {
-        cause: 'fallback_error',
-      }), 'fallback_error'),
-      true,
-    );
   }
 }
 
-export default successful3DS;
+export default handleSuccessful3DS;

--- a/src/subscription/data/utils.js
+++ b/src/subscription/data/utils.js
@@ -1,0 +1,39 @@
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
+/**
+ * sendSubscriptionEvent
+ * Use this method to send Subscription success/failure segment events
+ * @param {details, success}
+ */
+export const sendSubscriptionEvent = ({ details, success }) => {
+  const eventType = success
+    ? 'edx.bi.user.subscription.program.checkout.success'
+    : 'edx.bi.user.subscription.program.checkout.failure';
+
+  sendTrackEvent(
+    eventType,
+    {
+      paymentProcessor: details.paymentMethod,
+      isTrialEligible: details.isTrialEligible,
+      isNewSubscription: details.isTrialEligible,
+      programUuid: details.programUuid,
+      price: details.price,
+    },
+  );
+};
+
+/**
+ * handleCustomErrors
+ * Use this method to format error code so our Alert service
+ * could display it on the alerts
+ * @param {error, fallbackKey}
+ */
+export const handleCustomErrors = (error, fallbackKey) => {
+  const apiErrors = [{
+    code: fallbackKey || error.cause,
+    userMessage: error.message,
+  }];
+  const err = new Error();
+  err.errors = apiErrors;
+  return err;
+};

--- a/src/subscription/data/utils.test.js
+++ b/src/subscription/data/utils.test.js
@@ -1,0 +1,87 @@
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+
+import { sendSubscriptionEvent, handleCustomErrors } from './utils'; // Replace with the correct path to the file containing the functions.
+
+// Mock the sendTrackEvent function from '@edx/frontend-platform/analytics' for testing
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendTrackEvent: jest.fn(),
+}));
+
+describe('sendSubscriptionEvent', () => {
+  let details = null;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    details = {
+      paymentMethod: 'Stripe',
+      isTrialEligible: false,
+      isNewSubscription: false,
+      programUuid: '12345',
+      price: 79,
+    };
+  });
+
+  it('should call sendTrackEvent with success eventType', () => {
+    const success = true;
+
+    sendSubscriptionEvent({ details, success });
+
+    expect(sendTrackEvent).toHaveBeenCalledTimes(1);
+    expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.user.subscription.program.checkout.success', {
+      paymentProcessor: 'Stripe',
+      isTrialEligible: false,
+      isNewSubscription: false,
+      programUuid: '12345',
+      price: 79,
+    });
+  });
+
+  it('should call sendTrackEvent with failure eventType', () => {
+    const success = false;
+
+    sendSubscriptionEvent({
+      details: {
+        ...details,
+        isTrialEligible: true,
+        isNewSubscription: true,
+      },
+      success,
+    });
+
+    expect(sendTrackEvent).toHaveBeenCalledTimes(1);
+    expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.user.subscription.program.checkout.failure', {
+      paymentProcessor: 'Stripe',
+      isTrialEligible: true,
+      isNewSubscription: true,
+      programUuid: '12345',
+      price: 79,
+    });
+  });
+});
+
+describe('handleCustomErrors', () => {
+  it('should return an error object with the provided error code and message', () => {
+    const error = {
+      cause: 'SOME_ERROR_CODE',
+      message: 'Some error message',
+    };
+    const fallbackKey = null;
+
+    const result = handleCustomErrors(error, fallbackKey);
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.errors).toEqual([{ code: 'SOME_ERROR_CODE', userMessage: 'Some error message' }]);
+  });
+
+  it('should return an error object with the fallback error code and message if fallbackKey is provided', () => {
+    const error = {
+      cause: 'SOME_ERROR_CODE',
+      message: 'Some error message',
+    };
+    const fallbackKey = 'FALLBACK_ERROR_CODE';
+
+    const result = handleCustomErrors(error, fallbackKey);
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.errors).toEqual([{ code: 'FALLBACK_ERROR_CODE', userMessage: 'Some error message' }]);
+  });
+});

--- a/src/subscription/index.scss
+++ b/src/subscription/index.scss
@@ -101,9 +101,11 @@
 .secure-3d-modal {
   max-width: none !important;
   max-height: none !important;
-  height: 90vh;
+  height: 660px;
+  width: 400px;
   .secure-3ds-wrapper {
     height: 100%;
+    width: 100%;
     margin-bottom: 0;
   }
   iframe {

--- a/src/subscription/index.scss
+++ b/src/subscription/index.scss
@@ -26,9 +26,9 @@
     }
   }
   .product-wrapper {
-    .col-7 {
-      @extend .pl-0;
-    }
+    // .col-7 {
+    //   @extend .pl-0;
+    // }
     @include media-breakpoint-down(xl){
       @include product-title-column;
     }
@@ -101,9 +101,9 @@
 .secure-3d-modal {
   max-width: none !important;
   max-height: none !important;
-  height: 660px;
-  width: 400px;
-  overflow: hidden;
+  height: 660px !important;;
+  width: 400px !important;
+  overflow: hidden !important;;
   .secure-3ds-wrapper {
     height: 100%;
     width: 100%;

--- a/src/subscription/index.scss
+++ b/src/subscription/index.scss
@@ -103,6 +103,7 @@
   max-height: none !important;
   height: 660px;
   width: 400px;
+  overflow: hidden;
   .secure-3ds-wrapper {
     height: 100%;
     width: 100%;

--- a/src/subscription/index.scss
+++ b/src/subscription/index.scss
@@ -1,7 +1,7 @@
 
 .subscription-page {
   @mixin badge-responsive{
-    flex-direction: column-reverse;      
+    flex-direction: column-reverse;
     .badge{
       margin-bottom: 1rem;
     }
@@ -25,27 +25,27 @@
       @include badge-responsive;
     }
   }
-  .product-wrapper {    
-    .col-7 {          
-      @extend .pl-0;      
+  .product-wrapper {
+    .col-7 {
+      @extend .pl-0;
     }
-    @include media-breakpoint-down(xl){ 
+    @include media-breakpoint-down(xl){
       @include product-title-column;
-    }        
-    @include media-breakpoint-down(lg) { 
+    }
+    @include media-breakpoint-down(lg) {
       flex-direction: row;
       align-items: center !important;
       .col-7 {
         padding-left: 0px !important;
         margin-top: 0px !important;
       }
-    }   
+    }
     @include media-breakpoint-down(xs){
-      @include product-title-column;     
+      @include product-title-column;
       .col-5 .embed-responsive {
         min-width: 98px;
-      } 
-    } 
+      }
+    }
   }
   .basket-section.order-details{
     margin-bottom: 2rem !important;
@@ -68,7 +68,7 @@
   }
 
   .monthly-legal-notification p.micro {
-    font-size: 12px !important; 
+    font-size: 12px !important;
   }
   //skeleton changes
   .sub-cart-skeleton {
@@ -95,5 +95,18 @@
         justify-content: flex-end;
       }
     }
+  }
+}
+
+.secure-3d-modal {
+  max-width: none !important;
+  max-height: none !important;
+  height: 75vh;
+  .secure-3ds-wrapper {
+    height: 100%;
+    margin-bottom: 0;
+  }
+  iframe {
+    border: 0;
   }
 }

--- a/src/subscription/index.scss
+++ b/src/subscription/index.scss
@@ -101,7 +101,7 @@
 .secure-3d-modal {
   max-width: none !important;
   max-height: none !important;
-  height: 75vh;
+  height: 90vh;
   .secure-3ds-wrapper {
     height: 100%;
     margin-bottom: 0;

--- a/src/subscription/secure-3d/Secure3dRedirectPage.jsx
+++ b/src/subscription/secure-3d/Secure3dRedirectPage.jsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 
 /**
  * Secure3dRedirectPage
- * On the completion of 3DS step bank site will
- * redirect user to this page. On loading this
+ * On the completion of 3DS authentication from the bank site,
+ * user will be redirected to this page. Loading this
  * page will update its parent window that 3DS
  * flow has been completed and iframe, modal
  * should be close now.

--- a/src/subscription/secure-3d/Secure3dRedirectPage.jsx
+++ b/src/subscription/secure-3d/Secure3dRedirectPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 /**
  * Secure3dRedirectPage
@@ -9,7 +9,9 @@ import React from 'react';
  * should be close now.
  */
 export const Secure3dRedirectPage = () => {
-  window.top.postMessage('3DS-authentication-complete');
+  useEffect(() => {
+    window.top.postMessage('3DS-authentication-complete');
+  }, []);
   return (
     <div className="secure-page-container">
       <div className="spinner-border" />

--- a/src/subscription/secure-3d/Secure3dRedirectPage.jsx
+++ b/src/subscription/secure-3d/Secure3dRedirectPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+/**
+ * Secure3dRedirectPage
+ * On the completion of 3DS step bank site will
+ * redirect user to this page. On loading this
+ * page will update its parent window that 3DS
+ * flow has been completed and iframe, modal
+ * should be close now.
+ */
+export const Secure3dRedirectPage = () => {
+  window.top.postMessage('3DS-authentication-complete');
+  return (
+    <div className="secure-page-container">
+      <div className="spinner-border" />
+    </div>
+  );
+};
+
+export default Secure3dRedirectPage;

--- a/src/subscription/secure-3d/index.scss
+++ b/src/subscription/secure-3d/index.scss
@@ -1,0 +1,6 @@
+.secure-page-container{
+  height: 80vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/subscription/secure-3d/secure-3d-modal/Secure3DModal.test.jsx
+++ b/src/subscription/secure-3d/secure-3d-modal/Secure3DModal.test.jsx
@@ -1,0 +1,121 @@
+/* eslint-disable react/jsx-no-constructed-context-values */
+/* eslint-disable global-require */
+import React from 'react';
+import { Factory } from 'rosie';
+
+import '../../__factories__/subscription.factory';
+import '../../__factories__/subscriptionStatus.factory';
+
+import {
+  screen, render, act, store, // fireEvent
+} from '../../test-utils';
+import { Secure3DModal } from './Secure3dModal';
+import { fetchSubscriptionDetails, subscriptionDetailsReceived } from '../../data/details/actions';
+import { subscriptionStatusReceived } from '../../data/status/actions';
+
+import { camelCaseObject } from '../../../payment/data/utils';
+
+// Mock stripe and elements objects
+const setupIntentPromise = Promise.resolve({
+  error: false,
+  setupIntent: {
+    next_action: {
+      redirect_to_url: {
+        url: 'https://www.abcbank.com/3d/secure2/setupIntent/',
+      },
+    },
+  },
+});
+const paymentIntentPromise = Promise.resolve({
+  error: false,
+  paymentIntent: {
+    next_action: {
+      redirect_to_url: {
+        url: 'https://www.abcbank.com/3d/secure2/paymentIntent',
+      },
+    },
+  },
+});
+const stripeMock = {
+  retrieveSetupIntent: jest.fn(() => setupIntentPromise),
+  retrievePaymentIntent: jest.fn(() => paymentIntentPromise),
+};
+const elementsMock = {
+  clear: jest.fn(),
+  focus: jest.fn(),
+  getElement: jest.fn(),
+};
+
+/**
+ * Secure3DModal Test
+ */
+describe('<Secure3DModal />', () => {
+  it('should render the 3D Secure bank details with stripe.setupIntent when trial mode is true', async () => {
+    const subscriptionDetails = camelCaseObject(
+      Factory.build('subscription', { is_trial_eligible: true }, { numProducts: 2 }),
+    );
+    const subscriptionStatus = camelCaseObject(Factory.build('subscriptionStatus', {
+      status: 'requires_action',
+    }));
+
+    // Mock useEffect to bypass the fetchSecureDetails call
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+
+    const { container } = render(<Secure3DModal stripe={stripeMock} elements={elementsMock} />);
+    act(() => {
+      store.dispatch(
+        subscriptionDetailsReceived(subscriptionDetails),
+      );
+      store.dispatch(
+        subscriptionStatusReceived(subscriptionStatus),
+      );
+      store.dispatch(fetchSubscriptionDetails.fulfill());
+    });
+
+    await act(() => setupIntentPromise);
+    await act(() => paymentIntentPromise);
+
+    // Expect the modal to be rendered
+    // screen.debug();
+    expect(container.querySelector('#secure-3ds-wrapper')).toBeDefined();
+    expect(container.querySelector('#secure-3d-iframe')).toBeDefined();
+
+    // Ensure that loadSecureDetails is called with the correct URL
+    expect(stripeMock.retrieveSetupIntent).toHaveBeenCalledWith(subscriptionStatus.confirmationClientSecret);
+  });
+
+  it('should render the 3D Secure bank details with stripe.paymentIntent when trial mode is false', async () => {
+    const subscriptionDetails = camelCaseObject(
+      Factory.build('subscription', { is_trial_eligible: false }, { numProducts: 2 }),
+    );
+    const subscriptionStatus = camelCaseObject(Factory.build('subscriptionStatus', {
+      status: 'requires_action',
+    }));
+
+    // Mock useEffect to bypass the fetchSecureDetails call
+    jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+
+    act(() => {
+      store.dispatch(
+        subscriptionDetailsReceived(subscriptionDetails),
+      );
+      store.dispatch(
+        subscriptionStatusReceived(subscriptionStatus),
+      );
+      store.dispatch(fetchSubscriptionDetails.fulfill());
+    });
+
+    const { container } = render(<Secure3DModal stripe={stripeMock} elements={elementsMock} />);
+    await act(() => setupIntentPromise);
+    await act(() => paymentIntentPromise);
+
+    // Expect the modal to be rendered
+    screen.debug();
+    const iframe = container.querySelector('#secure-3d-iframe');
+    expect(iframe).toBeDefined();
+    expect(container.querySelector('#secure-3d-iframe')).toBeDefined();
+
+    // Ensure that loadSecureDetails is called with the correct URL
+    expect(stripeMock.retrievePaymentIntent).toHaveBeenCalledWith(subscriptionStatus.confirmationClientSecret);
+  });
+});

--- a/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
@@ -39,6 +39,7 @@ export const Secure3DModal = ({ stripe, elements }) => {
       const container = document.getElementById('secure-3ds-wrapper');
       const iframe = document.createElement('iframe');
       iframe.src = url;
+      iframe.id = 'secure-3d-iframe';
       iframe.width = '100%';
       iframe.height = '100%';
       container.appendChild(iframe);

--- a/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
@@ -25,7 +25,7 @@ import {
  */
 export const Secure3DModal = ({ stripe, elements }) => {
   const dispatch = useDispatch();
-  const modalRef = useRef('inActive');
+  const modalRef = useRef('inactive');
   const [isOpen, setOpen] = useState(false);
 
   const { isTrialEligible } = useSelector(detailsSelector);
@@ -72,8 +72,8 @@ export const Secure3DModal = ({ stripe, elements }) => {
   const on3DSComplete = async () => {
     // Hide the 3DS UI
     if (modalRef.current === 'active') {
-      // completed 3DS, set to inActive so multiple state updates doesn't trigger the 3DS update
-      modalRef.current = 'inActive';
+      // completed 3DS, set to inactive so multiple state updates doesn't trigger the 3DS update
+      modalRef.current = 'inactive';
       dispatch(onSuccessful3DS({}));
       window.removeEventListener('message', null);
     }

--- a/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
@@ -21,6 +21,9 @@ export const Secure3DModal = ({ stripe }) => {
   const { isTrialEligible } = useSelector(detailsSelector);
   const [isOpen, setOpen] = useState(false);
 
+  /**
+   * loadSecureDetails
+   */
   const loadSecureDetails = (url) => {
     setTimeout(() => {
       const container = document.getElementById('secure-3ds-wrapper');
@@ -35,32 +38,56 @@ export const Secure3DModal = ({ stripe }) => {
   const retrieveSetupIntent = async () => {
     const response = await stripe.retrieveSetupIntent(confirmationClientSecret);
     if (response.error) { throw response.error; }
-    return response.setupIntent.next_action.redirect_to_url.url;
+    return response.setupIntent;
   };
 
   const retrievePaymentIntent = async () => {
     const response = await stripe.retrievePaymentIntent(confirmationClientSecret);
     if (response.error) { throw response.error; }
-    return response.paymentIntent.next_action.redirect_to_url.url;
+    return response.paymentIntent;
   };
 
   const fetchSecureDetails = async () => {
     try {
       const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
-      const secureUrl = await fetchPaymentDetails();
-      loadSecureDetails(secureUrl);
+      const paymentDetails = await fetchPaymentDetails();
+      loadSecureDetails(paymentDetails.next_action.redirect_to_url.url);
       setOpen(true);
     } catch (e) {
+      // TODO: log the error to segment
       throw new Error(`Error loading 3D secure details): ${e.message}`);
     }
   };
 
   useEffect(() => {
-    if (status === '3DS') {
+    if (status === '3DS' || status === 'trialing') {
       fetchSecureDetails();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
+
+  const on3DSComplete = async () => {
+    // Hide the 3DS UI
+    setOpen(false);
+    try {
+      const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
+      const paymentDetails = await fetchPaymentDetails();
+      if (paymentDetails.paymentIntent.status === 'succeeded') {
+        // Show your customer that the payment has succeeded
+      } else if (paymentDetails.paymentIntent.status === 'requires_payment_method') {
+        // Authentication failed, prompt the customer to enter another payment method
+      }
+    } catch (e) {
+      // TODO: log the error to segment
+      throw new Error(`Error loading 3D secure details): ${e.message}`);
+    }
+  };
+
+  window.addEventListener('message', (ev) => {
+    if (ev.data === '3DS-authentication-complete') {
+      on3DSComplete();
+    }
+  }, false);
 
   if (!isOpen) { return null; }
 

--- a/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
+++ b/src/subscription/secure-3d/secure-3d-modal/Secure3dModal.jsx
@@ -1,29 +1,40 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
 
 import {
   ModalDialog,
 } from '@edx/paragon';
-import { useSelector } from 'react-redux';
+import {
+  PaymentElement,
+} from '@stripe/react-stripe-js';
 
 import { subscriptionStatusSelector } from '../../data/status/selectors';
 import { detailsSelector } from '../../data/details/selectors';
+
+import {
+  handleSuccessful3DS,
+  handleUnSuccessful3DS,
+} from '../../data/status/actions';
 
 /**
  * Secure3DModal
  * This modal implements the 3DS functionality for
  * both trial and non-trial purchases. It uses the setupIntent
- * for trial and paymentIntent function for non-trial
+ * for trial and paymentIntent for non-trial
  * purchases in order to load 3DS details inside an iFrame modal
  */
 export const Secure3DModal = ({ stripe, elements }) => {
-  const { status, confirmationClientSecret } = useSelector(subscriptionStatusSelector);
-  const { isTrialEligible } = useSelector(detailsSelector);
+  const dispatch = useDispatch();
+  const modalRef = useRef(false);
   const [isOpen, setOpen] = useState(false);
+
+  const { isTrialEligible } = useSelector(detailsSelector);
+  const { status, confirmationClientSecret } = useSelector(subscriptionStatusSelector);
 
   /**
    * loadSecureDetails
-   */
+  */
   const loadSecureDetails = (url) => {
     setTimeout(() => {
       const container = document.getElementById('secure-3ds-wrapper');
@@ -35,24 +46,82 @@ export const Secure3DModal = ({ stripe, elements }) => {
     });
   };
 
+  /**
+   * retrieveSetupIntent
+   * call this method with subscription in trial mode
+   */
   const retrieveSetupIntent = async () => {
     const response = await stripe.retrieveSetupIntent(confirmationClientSecret);
     if (response.error) { throw response.error; }
     return response.setupIntent;
   };
 
+  /**
+   * retrievePaymentIntent
+   * call this method with subscription in non-trial mode
+   */
   const retrievePaymentIntent = async () => {
     const response = await stripe.retrievePaymentIntent(confirmationClientSecret);
     if (response.error) { throw response.error; }
     return response.paymentIntent;
   };
 
+  /**
+   * on3DSComplete
+   * callback to handle 3DS completion state
+   */
+  const on3DSComplete = async () => {
+    // Hide the 3DS UI
+    if (modalRef.current === 'active') {
+      // completed 3DS, set to inActive so multiple state updates doesn't trigger the 3DS update
+      modalRef.current = 'inActive';
+      const error = new Error('Could not complete the payment', { cause: 'requires_payment_method' });
+      try {
+        const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
+        const paymentDetails = await fetchPaymentDetails();
+        if (paymentDetails.status === 'succeeded') {
+          // Show your customer that the payment has succeeded
+          dispatch(handleSuccessful3DS({ status: paymentDetails.status }));
+        } else if (paymentDetails.status === 'requires_payment_method') {
+          // clear the stripe elements and ask user to submit new details
+          // Authentication failed, prompt the customer to enter another payment method
+          const paymentElement = elements.getElement(PaymentElement);
+          paymentElement.clear();
+          paymentElement.focus();
+          dispatch(handleUnSuccessful3DS({ error }));
+        } else {
+          // Status unknown
+          dispatch(handleUnSuccessful3DS({ error }));
+        }
+        window.removeEventListener('message', null);
+        setOpen(false);
+      } catch (e) {
+        setOpen(false);
+        dispatch(handleUnSuccessful3DS({ error }));
+        window.removeEventListener('message', null);
+      }
+    }
+  };
+
+  /**
+   * fetchSecureDetails
+   * fetches the 3D secure details
+   */
   const fetchSecureDetails = async () => {
     try {
       const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
       const paymentDetails = await fetchPaymentDetails();
       loadSecureDetails(paymentDetails.next_action.redirect_to_url.url);
-      setOpen(true);
+      setOpen(() => {
+        // attempting 3ds, because state changes doesn't work with window listeners
+        modalRef.current = 'active';
+        return true;
+      });
+      window.addEventListener('message', (ev) => {
+        if (ev.data === '3DS-authentication-complete') {
+          on3DSComplete();
+        }
+      }, false);
     } catch (e) {
       // TODO: log the error to segment
       throw new Error(`Error loading 3D secure details): ${e.message}`);
@@ -63,38 +132,10 @@ export const Secure3DModal = ({ stripe, elements }) => {
     if (status === 'requires_action') {
       fetchSecureDetails();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
 
-  const on3DSComplete = async () => {
-    // Hide the 3DS UI
-    setOpen(false);
-    try {
-      const fetchPaymentDetails = isTrialEligible ? retrieveSetupIntent : retrievePaymentIntent;
-      const paymentDetails = await fetchPaymentDetails();
-      if (paymentDetails.status === 'succeeded') {
-        // Show your customer that the payment has succeeded
-        console.log('make stripe-fulfill api call');
-      } else if (paymentDetails.status === 'requires_payment_method') {
-        elements.clear();
-        elements.focus();
-
-        // Authentication failed, prompt the customer to enter another payment method
-        console.log('clear the stripe elements and ask user to submit new details');
-      }
-    } catch (e) {
-      // TODO: log the error to segment
-      throw new Error(`Error loading 3D secure details): ${e.message}`);
-    }
-  };
-
-  window.addEventListener('message', (ev) => {
-    if (ev.data === '3DS-authentication-complete') {
-      on3DSComplete();
-    }
-  }, false);
-
-  if (!isOpen) { return null; }
+  if (!isOpen || !stripe || !elements) { return null; }
 
   return (
     <ModalDialog
@@ -114,11 +155,17 @@ Secure3DModal.propTypes = {
   stripe: PropTypes.shape({
     retrievePaymentIntent: () => {},
     retrieveSetupIntent: () => {},
-  }).isRequired,
+  }),
   elements: PropTypes.shape({
     clear: () => {},
     focus: () => {},
-  }).isRequired,
+    getElement: () => {},
+  }),
+};
+
+Secure3DModal.defaultProps = {
+  stripe: null,
+  elements: null,
 };
 
 export default Secure3DModal;


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

Ticket: [PON-161](https://2u-internal.atlassian.net/browse/PON-161)
This PR implements the 3DS workflow for both `trial` and `non-trial` mode. 
- It fetches the Secure details from the stripe and display it within iframe
- It renders the iframe inside the model. 
- It introduce a new 3DS redirect page which tell it's parent that 3DS flow has been completed. 
- It makes another API request `stripe-checkout-complete` endpoint to confirm the 3DS workflow has been done. 


<img width="556" alt="Screenshot 2023-07-12 at 5 42 20 PM" src="https://github.com/openedx/frontend-app-payment/assets/5585262/cce7520f-1d24-40f6-b9a2-f07dc7006c69">
<img width="852" alt="Screenshot 2023-07-12 at 5 46 33 PM" src="https://github.com/openedx/frontend-app-payment/assets/5585262/a8455863-504e-42f2-8918-a2e9e685c2bf">
