### PR TITLE
feat: Added stripe redirect content-security-policy meta tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-helmet": "^6.1.0",
         "react-redux": "^7.2.8",
         "react-router-dom": "^5.3.3",
         "react-tooltip": "^4.2.21",
@@ -15767,6 +15768,20 @@
         }
       }
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-intl": {
       "version": "5.25.1",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-5.25.1.tgz",
@@ -15995,6 +16010,14 @@
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-helmet": "^6.1.0",
     "react-redux": "^7.2.8",
     "react-router-dom": "^5.3.3",
     "react-tooltip": "^4.2.21",

--- a/src/components/helmet-header/HelmetHeader.jsx
+++ b/src/components/helmet-header/HelmetHeader.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+/**
+ * HelmetHeader
+ * using this header to apply stripe redirect url
+ * content security policy as mentioned here for 3DS
+ * https://stripe.com/docs/security/guide#content-security-policy
+ */
+export const HelmetHeader = () => (
+  <Helmet>
+    <meta
+      httpEquiv="Content-Security-Policy"
+      content="
+        frame-src 'self' https://js.stripe.com https://hooks.stripe.com
+      "
+    />
+  </Helmet>
+);
+
+export default HelmetHeader;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,7 +36,7 @@ import {
 } from './payment';
 import { SubscriptionPage } from './subscription';
 import { Secure3dRedirectPage } from './subscription/secure-3d/Secure3dRedirectPage';
-
+import { HelmetHeader } from './components/helmet-header/HelmetHeader';
 import configureStore from './data/configureStore';
 
 import './index.scss';
@@ -86,6 +86,7 @@ subscribe(APP_READY, () => {
 
   ReactDOM.render(
     <AppProvider store={configureStore()}>
+      <HelmetHeader />
       <Header />
       <main id="main">
         <Switch>


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

This pull request uses `react-helmet` package to add Stripe content security policy meta tag to allow bank sites to redirect to payment MFE after successful 3DS. 

https://stripe.com/docs/security/guide#content-security-policy