### PR TITLE
fix: Checkout Bulk purchase 'Max' alignment fixed

### DIFF
--- a/src/payment/__snapshots__/PaymentPage.test.jsx.snap
+++ b/src/payment/__snapshots__/PaymentPage.test.jsx.snap
@@ -2394,10 +2394,10 @@ exports[`<PaymentPage /> Renders correctly in various states should render the b
                   Quantity
                 </label>
                 <div
-                  className="position-relative"
+                  className="position-relative ml-2"
                 >
                   <div
-                    className="pgn__form-control-decorator-group form-control-sm"
+                    className="pgn__form-control-decorator-group"
                   >
                     <input
                       className="has-value form-control"

--- a/src/payment/cart/UpdateQuantityForm.jsx
+++ b/src/payment/cart/UpdateQuantityForm.jsx
@@ -33,9 +33,8 @@ const UpdateQuantityForm = (props) => {
             description="Label for updating a quantity of enrollment codes to purchase"
           />
         </label>
-        <div className="position-relative">
+        <div className="position-relative ml-2">
           <Form.Control
-            className="form-control-sm"
             name={id}
             id={id}
             max="100"

--- a/src/payment/cart/__snapshots__/Cart.test.jsx.snap
+++ b/src/payment/cart/__snapshots__/Cart.test.jsx.snap
@@ -335,10 +335,10 @@ exports[`<Cart /> renders a bulk enrollment cart 1`] = `
             Quantity
           </label>
           <div
-            className="position-relative"
+            className="position-relative ml-2"
           >
             <div
-              className="pgn__form-control-decorator-group form-control-sm"
+              className="pgn__form-control-decorator-group"
             >
               <input
                 className="has-value form-control"


### PR DESCRIPTION
Checkout page has a design alignment issue under Quantity section. Just added and removed some style's classes of components.
Ticket: [REV-3615](https://2u-internal.atlassian.net/browse/REV-3615)