### PR TITLE
temp: disable stripe advanced fraud protection

### DIFF
--- a/src/payment/checkout/Checkout.jsx
+++ b/src/payment/checkout/Checkout.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { loadStripe } from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js/pure';
 import { Elements } from '@stripe/react-stripe-js';
 import {
   getLocale,
@@ -226,6 +226,7 @@ class Checkout extends React.Component {
     // Doing this within the Checkout component so locale is configured and available
     let stripePromise;
     if (shouldDisplayStripePaymentForm) {
+      loadStripe.setParameters({ advancedFraudSignals: false });
       stripePromise = loadStripe(process.env.STRIPE_PUBLISHABLE_KEY, {
         betas: [process.env.STRIPE_BETA_FLAG],
         apiVersion: process.env.STRIPE_API_VERSION,


### PR DESCRIPTION
## Description

Our Stripe Elements integration is currently adding a key called `radar_options[hcaptcha_token]` to our Stripe requests.For some reason, Stripe API does not recognize requests with `radar_options[hcaptcha_token]` as a valid request, even when Stripe's own Elements library is the one adding `radar_options[hcaptcha_token]` into the request.

The error message Stripe's API gives us is: "Received unknown parameter: radar_options".

This commit attempts to temporarily disable Stripe's advanced fraud protection, which includes hCaptcha verification, to see if the problem resolves.

## Additional Information

* Jira: [REV-3863](https://2u-internal.atlassian.net/jira/software/c/projects/REV/issues/REV-3863)
* Stripe docs:
  * [Stripe.js README](https://github.com/stripe/stripe-js?tab=readme-ov-file#disabling-advanced-fraud-detection-signals)
  * [Stripe docs on Advanced fraud detection](https://docs.stripe.com/disputes/prevention/advanced-fraud-detection#disable-advanced-fraud-detection)

## Checklist
- [X] Consider PCI compliance impact and whether this PR changes how credit card information is handled.
- [X] Intend to [release and monitor](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories) this PR promptly after merge.
