### PR TITLE
feat: Add grey color for disabled selects during the form submission

### DIFF
--- a/src/payment/index.scss
+++ b/src/payment/index.scss
@@ -54,6 +54,14 @@
   }
   .basket-section {
     @extend .mb-5;
+
+    select#cardExpirationMonth,
+    select#cardExpirationYear,
+    select#country {
+      &:disabled {
+        background-color: $gray-100 !important;
+      }
+    }
   }
   .summary-row {
     margin-bottom: map-get($spacers, 3);


### PR DESCRIPTION
This is backport from master - https://github.com/openedx/frontend-app-payment/pull/715

## Description

This cosmetic enhancement for payment form. After pressing "Place Order" button - we can see that all inputs became disabled, but selects - no. It looks not consistent and we decided to fix this small issue.

https://user-images.githubusercontent.com/19806032/223077832-32d796c9-cf39-43c5-8bbf-4471b1f0c491.mov

The result:

https://user-images.githubusercontent.com/19806032/223078291-736d4df8-8bdf-481e-85c6-27c5f56e00e6.mov